### PR TITLE
Add MNEMON_EMBED_DIMENSIONS for Matryoshka dimension truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `MNEMON_EMBED_DIMENSIONS` env var for Matryoshka dimension truncation (e.g., 256-dim instead of 768)
+
 ## [0.1.1] - 2026-02-22
 
 ### Added

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -183,6 +183,7 @@ Nodes are colored by category (decision, fact, insight, preference, context); ed
 | `MNEMON_STORE` | `default` | Active named store |
 | `MNEMON_EMBED_ENDPOINT` | `http://localhost:11434` | Ollama API endpoint |
 | `MNEMON_EMBED_MODEL` | `nomic-embed-text` | Ollama embedding model |
+| `MNEMON_EMBED_DIMENSIONS` | (native) | Embedding dimensions; set to truncate (e.g., `256` for Matryoshka models) |
 
 ---
 

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -21,11 +22,13 @@ const DefaultEndpoint = "http://localhost:11434"
 type Client struct {
 	endpoint string
 	model    string
+	dims     int // 0 means use native dimensions
 	http     *http.Client
 }
 
 // NewClient creates an Ollama embedding client.
-// It checks MNEMON_EMBED_ENDPOINT and MNEMON_EMBED_MODEL env vars.
+// It checks MNEMON_EMBED_ENDPOINT, MNEMON_EMBED_MODEL, and
+// MNEMON_EMBED_DIMENSIONS env vars.
 func NewClient() *Client {
 	endpoint := os.Getenv("MNEMON_EMBED_ENDPOINT")
 	if endpoint == "" {
@@ -35,9 +38,16 @@ func NewClient() *Client {
 	if model == "" {
 		model = DefaultModel
 	}
+	dims := 0
+	if d := os.Getenv("MNEMON_EMBED_DIMENSIONS"); d != "" {
+		if v, err := strconv.Atoi(d); err == nil && v > 0 {
+			dims = v
+		}
+	}
 	return &Client{
 		endpoint: endpoint,
 		model:    model,
+		dims:     dims,
 		http: &http.Client{
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
@@ -80,8 +90,9 @@ func (c *Client) Endpoint() string {
 }
 
 type embedRequest struct {
-	Model string `json:"model"`
-	Input string `json:"input"`
+	Model      string `json:"model"`
+	Input      string `json:"input"`
+	Dimensions int    `json:"dimensions,omitempty"`
 }
 
 type embedResponse struct {
@@ -90,7 +101,11 @@ type embedResponse struct {
 
 // Embed generates an embedding vector for the given text.
 func (c *Client) Embed(text string) ([]float64, error) {
-	body, err := json.Marshal(embedRequest{Model: c.model, Input: text})
+	req := embedRequest{Model: c.model, Input: text}
+	if c.dims > 0 {
+		req.Dimensions = c.dims
+	}
+	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}


### PR DESCRIPTION
Closes #4

Support [Matryoshka Representation Learning](https://arxiv.org/abs/2205.13147) by passing the `dimensions` parameter to Ollama's `/api/embed` endpoint. When `MNEMON_EMBED_DIMENSIONS` is set (e.g., `256`), Ollama truncates and re-normalizes the embedding vector, giving faster similarity search with minimal quality loss on MRL-trained models like `nomic-embed-text`.

Backward compatible: when unset, behavior is identical to before.

## What

- Added `dims` field to the `Client` struct (`0` = use native dimensions)
- `NewClient()` reads the `MNEMON_EMBED_DIMENSIONS` env var (parsed as int, ignores invalid/negative values)
- Added `Dimensions` field to `embedRequest` with `json:"dimensions,omitempty"` so it's only included when set
- `Embed()` conditionally populates `req.Dimensions` when `dims > 0`
- Updated `CHANGELOG.md` under `[Unreleased]`
- Updated `docs/USAGE.md` Configuration table with the new env var

## Why

Here is the [issue](https://github.com/mnemon-dev/mnemon/issues/4) which describes the problem.

Matryoshka-trained models encode the most important semantic signal in the first *N* dimensions. Using 256 dims instead of 768 gives ~95% retrieval quality at 3× less storage and faster cosine similarity. This is especially impactful for large knowledge bases where similarity search dominates recall latency.

## Verified locally

Tested against Ollama `nomic-embed-text` on macOS:

```bash
# Without dimensions → 768-dim vector
curl -s http://localhost:11434/api/embed \
  -d '{"model":"nomic-embed-text","input":"test query"}' 
# → Vector length: 768

# With dimensions: 256 → 256-dim vector
curl -s http://localhost:11434/api/embed \
  -d '{"model":"nomic-embed-text","input":"test query","dimensions":256}'
# → Vector length: 256
```

> [!WARNING]  
> **Re-indexing caveat**
> If users change dimensions on an existing store, old embeddings (768-dim) and new embeddings (256-dim) will have incompatible vector sizes. For this PR, the env var only affects newly generated embeddings. A follow-up could add a `mnemon embed --reindex` command.
