### PR TITLE
Add privacy-safe memory receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ memory is useful.
 - **Intent-aware recall** — graph traversal + optional vector search (RRF fusion), enabled by default for all queries
 - **Built-in deduplication** — `remember` auto-detects duplicates and conflicts; skips or auto-replaces
 - **Retention lifecycle** — importance decay, access-count boosting, and garbage collection
+- **Privacy-safe receipts** — export hashed operation receipts for memory-boundary audits without raw memory contents or queries
 - **Optional embeddings** — works fully without Ollama; add local [Ollama](https://ollama.ai) for enhanced vector+keyword hybrid search
 
 ## Vision

--- a/cmd/receipt.go
+++ b/cmd/receipt.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mnemon-dev/mnemon/internal/store"
+	"github.com/spf13/cobra"
+)
+
+var receiptLimit int
+
+type receiptDocument struct {
+	Schema      string         `json:"schema"`
+	GeneratedAt string         `json:"generated_at"`
+	Store       string         `json:"store"`
+	Limit       int            `json:"limit"`
+	Count       int            `json:"count"`
+	Privacy     receiptPrivacy `json:"privacy"`
+	Events      []receiptEvent `json:"events"`
+}
+
+type receiptPrivacy struct {
+	RawDetailIncluded bool   `json:"raw_detail_included"`
+	HashAlgorithm     string `json:"hash_algorithm"`
+	Note              string `json:"note"`
+}
+
+type receiptEvent struct {
+	EventName     string `json:"event_name"`
+	Operation     string `json:"operation"`
+	CreatedAt     string `json:"created_at"`
+	InsightIDHash string `json:"insight_id_hash,omitempty"`
+	DetailHash    string `json:"detail_hash,omitempty"`
+	DetailPresent bool   `json:"detail_present"`
+}
+
+var receiptCmd = &cobra.Command{
+	Use:   "receipt",
+	Short: "Export a privacy-safe memory operation receipt",
+	Long: `Export a JSON receipt for recent memory operations without printing raw memory
+contents, queries, paths, or operation details. The receipt hashes identifiers and
+details so it can be shared for audits of what crossed the memory boundary.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requirePositiveLimit("--limit", receiptLimit); err != nil {
+			return err
+		}
+
+		db, err := openDB()
+		if err != nil {
+			return fmt.Errorf("open database: %w", err)
+		}
+		defer db.Close()
+
+		entries, err := db.GetOplog(receiptLimit)
+		if err != nil {
+			return fmt.Errorf("get oplog: %w", err)
+		}
+
+		doc := buildReceipt(resolveStoreName(), receiptLimit, entries, time.Now().UTC())
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(doc)
+	},
+}
+
+func init() {
+	receiptCmd.Flags().IntVar(&receiptLimit, "limit", 20, "max operations to include")
+	rootCmd.AddCommand(receiptCmd)
+}
+
+func buildReceipt(storeName string, limit int, entries []store.OplogEntry, generatedAt time.Time) receiptDocument {
+	events := make([]receiptEvent, 0, len(entries))
+	for _, entry := range entries {
+		event := receiptEvent{
+			EventName:     "mnemon.memory.operation.observed",
+			Operation:     entry.Operation,
+			CreatedAt:     entry.CreatedAt,
+			InsightIDHash: hashIfPresent(entry.InsightID),
+			DetailHash:    hashIfPresent(entry.Detail),
+			DetailPresent: entry.Detail != "",
+		}
+		events = append(events, event)
+	}
+
+	return receiptDocument{
+		Schema:      "mnemon.memory.receipt.v1",
+		GeneratedAt: generatedAt.Format(time.RFC3339),
+		Store:       storeName,
+		Limit:       limit,
+		Count:       len(events),
+		Privacy: receiptPrivacy{
+			RawDetailIncluded: false,
+			HashAlgorithm:     "sha256",
+			Note:              "Raw memory contents, recall queries, paths, and operation details are omitted; only hashes and operation metadata are emitted.",
+		},
+		Events: events,
+	}
+}
+
+func hashIfPresent(value string) string {
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/cmd/receipt_test.go
+++ b/cmd/receipt_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mnemon-dev/mnemon/internal/store"
+)
+
+func TestBuildReceiptOmitsRawDetails(t *testing.T) {
+	generatedAt := time.Date(2026, 5, 23, 16, 0, 0, 0, time.UTC)
+	entries := []store.OplogEntry{
+		{
+			Operation: "remember",
+			InsightID: "ins-secret-123",
+			Detail:    "customer ACME had incident sk_live_private_demo in /private/path",
+			CreatedAt: "2026-05-23T15:59:00Z",
+		},
+		{
+			Operation: "recall",
+			Detail:    "q=private roadmap hits=3",
+			CreatedAt: "2026-05-23T15:59:30Z",
+		},
+	}
+
+	doc := buildReceipt("default", 20, entries, generatedAt)
+	if doc.Schema != "mnemon.memory.receipt.v1" {
+		t.Fatalf("unexpected schema: %s", doc.Schema)
+	}
+	if doc.GeneratedAt != generatedAt.Format(time.RFC3339) {
+		t.Fatalf("unexpected generated_at: %s", doc.GeneratedAt)
+	}
+	if doc.Count != 2 || len(doc.Events) != 2 {
+		t.Fatalf("unexpected event count: count=%d len=%d", doc.Count, len(doc.Events))
+	}
+	if doc.Privacy.RawDetailIncluded {
+		t.Fatal("receipt should not include raw details")
+	}
+
+	rendered := doc.Events[0].DetailHash + doc.Events[0].InsightIDHash + doc.Events[1].DetailHash
+	for _, forbidden := range []string{"ACME", "sk_live_private_demo", "/private/path", "private roadmap", "ins-secret-123"} {
+		if strings.Contains(rendered, forbidden) {
+			t.Fatalf("receipt leaked raw value %q in hashes: %s", forbidden, rendered)
+		}
+	}
+	if doc.Events[0].DetailHash == "" || doc.Events[0].InsightIDHash == "" {
+		t.Fatal("expected hashes for non-empty detail and insight id")
+	}
+	if !doc.Events[0].DetailPresent || !doc.Events[1].DetailPresent {
+		t.Fatal("expected detail_present for entries with detail")
+	}
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -154,9 +154,37 @@ Different agents or processes can use different stores via the `MNEMON_STORE` en
 ### Observability
 
 ```bash
-mnemon status           # memory statistics
-mnemon log              # operation log (default: last 20)
-mnemon log --limit 50   # show more entries
+mnemon status              # memory statistics
+mnemon log                 # operation log (default: last 20)
+mnemon log --limit 50      # show more entries
+mnemon receipt             # JSON receipt with hashed recent operations
+mnemon receipt --limit 50  # include more operations in the receipt
+```
+
+`mnemon receipt` is for sharing or archiving memory-boundary evidence without
+publishing raw memories, recall queries, paths, or operation details. It emits
+operation names, timestamps, and SHA-256 hashes for identifiers/details so a
+team can prove that `remember`, `recall`, `forget`, or GC activity happened
+without exposing the underlying content.
+
+Example shape:
+
+```json
+{
+  "schema": "mnemon.memory.receipt.v1",
+  "privacy": {
+    "raw_detail_included": false,
+    "hash_algorithm": "sha256"
+  },
+  "events": [
+    {
+      "event_name": "mnemon.memory.operation.observed",
+      "operation": "remember",
+      "detail_present": true,
+      "detail_hash": "..."
+    }
+  ]
+}
 ```
 
 ### Visualization


### PR DESCRIPTION
## Summary

Adds `mnemon receipt`, a JSON export for recent memory operations that is safe to share in reviews or incident handoffs because it does **not** print raw memory contents, recall queries, paths, or operation details.

The receipt includes:

- schema/version metadata
- operation names and timestamps
- SHA-256 hashes for insight IDs and operation details
- an explicit privacy block documenting that raw details are omitted

This is meant to complement the existing `mnemon log`: `log` is useful locally, while `receipt` is useful when a team needs boundary evidence without exposing private memory content.

## Why

The README already frames Mnemon as an event-sourced lifecycle layer around memory/skill/eval/proposal/audit lifecycles. A small receipt export gives teams a practical audit artifact for questions like:

- did the agent write/recall/forget memory during this run?
- can we show memory-boundary activity without pasting customer notes, queries, paths, or secrets?
- can a handoff preserve evidence without leaking the memory body?

## Validation

- `gofmt -w cmd/receipt.go cmd/receipt_test.go`
- `go test ./...`
- `git diff --check`
- smoke: created a temp store with a synthetic secret-bearing memory, ran `mnemon receipt`, and checked the receipt did not include the raw synthetic strings
