### PR TITLE
feat(embed): add --embed-model CLI flag for runtime model override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- `--embed-model` global flag (with existing `MNEMON_EMBED_MODEL` env var as
+  default) lets callers override the Ollama embedding model per-command
+  without exporting the env var, making it easier to use multilingual models
+  such as `nomic-embed-text-v2-moe:latest` for non-English or code-switched
+  corpora. The flag and env var apply consistently across `embed`, `recall`,
+  and `remember` so vectors stay comparable.
+
 ## [0.1.7] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- `--embed-model` global flag (with existing `MNEMON_EMBED_MODEL` env var as
-  default) lets callers override the Ollama embedding model per-command
-  without exporting the env var, making it easier to use multilingual models
-  such as `nomic-embed-text-v2-moe:latest` for non-English or code-switched
-  corpora. The flag and env var apply consistently across `embed`, `recall`,
-  and `remember` so vectors stay comparable.
+- `--embed-model` global flag exposes the existing `MNEMON_EMBED_MODEL` env
+  var on the CLI, applied consistently across `embed`, `recall`, and
+  `remember`. Useful for switching to multilingual models such as
+  `nomic-embed-text-v2-moe:latest` on code-switched corpora without exporting
+  the env var. Note: switching to a model with a different output dimension
+  silently invalidates existing embeddings — backfill after changing.
 
 ## [0.1.7] - 2026-05-23
 

--- a/cmd/embed.go
+++ b/cmd/embed.go
@@ -30,7 +30,7 @@ Modes:
 		}
 		defer db.Close()
 
-		ec := embed.NewClient()
+		ec := embed.NewClientWithModel(resolveEmbedModel())
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -73,7 +73,7 @@ var recallCmd = &cobra.Command{
 
 		// Try to get query embedding for hybrid search
 		var queryVec []float64
-		ec := embed.NewClient()
+		ec := embed.NewClientWithModel(resolveEmbedModel())
 		if ec.Available() {
 			queryVec, _ = ec.Embed(keyword)
 		}

--- a/cmd/remember.go
+++ b/cmd/remember.go
@@ -109,7 +109,7 @@ var rememberCmd = &cobra.Command{
 		// 1. Compute embedding BEFORE the transaction (HTTP call should not hold a DB lock)
 		var embeddingBlob []byte
 		var embeddingVec []float64
-		ec := embed.NewClient()
+		ec := embed.NewClientWithModel(resolveEmbedModel())
 		if ec.Available() {
 			if vec, err := ec.Embed(content); err == nil {
 				embeddingVec = vec

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mnemon-dev/mnemon/internal/embed"
 	"github.com/mnemon-dev/mnemon/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -12,9 +13,10 @@ import (
 var version = "dev"
 
 var (
-	dataDir   string
-	storeName string
-	readOnly  bool
+	dataDir    string
+	storeName  string
+	readOnly   bool
+	embedModel string
 )
 
 var rootCmd = &cobra.Command{
@@ -36,9 +38,22 @@ func init() {
 	if env := os.Getenv("MNEMON_DATA_DIR"); env != "" {
 		defaultDataDir = env
 	}
+	defaultEmbedModel := os.Getenv("MNEMON_EMBED_MODEL")
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", defaultDataDir, "base data directory (env: MNEMON_DATA_DIR)")
 	rootCmd.PersistentFlags().StringVar(&storeName, "store", "", "named memory store (overrides MNEMON_STORE and active file)")
 	rootCmd.PersistentFlags().BoolVar(&readOnly, "readonly", false, "open database in read-only mode (no WAL files, safe for read-only mounts)")
+	rootCmd.PersistentFlags().StringVar(&embedModel, "embed-model", defaultEmbedModel, fmt.Sprintf("Ollama embedding model used by embed/recall/remember (env: MNEMON_EMBED_MODEL, default: %s)", embed.DefaultModel))
+}
+
+// resolveEmbedModel returns the embedding model to pass into
+// embed.NewClientWithModel. Priority: --embed-model flag > MNEMON_EMBED_MODEL
+// env var > embed.DefaultModel (resolved inside NewClientWithModel).
+//
+// The empty string return value is intentional: it lets the embed package
+// apply its own env/default fallback chain and remain the single source of
+// truth for that resolution.
+func resolveEmbedModel() string {
+	return embedModel
 }
 
 // resolveStoreName returns the effective store name.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,20 +38,26 @@ func init() {
 	if env := os.Getenv("MNEMON_DATA_DIR"); env != "" {
 		defaultDataDir = env
 	}
-	defaultEmbedModel := os.Getenv("MNEMON_EMBED_MODEL")
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", defaultDataDir, "base data directory (env: MNEMON_DATA_DIR)")
 	rootCmd.PersistentFlags().StringVar(&storeName, "store", "", "named memory store (overrides MNEMON_STORE and active file)")
 	rootCmd.PersistentFlags().BoolVar(&readOnly, "readonly", false, "open database in read-only mode (no WAL files, safe for read-only mounts)")
-	rootCmd.PersistentFlags().StringVar(&embedModel, "embed-model", defaultEmbedModel, fmt.Sprintf("Ollama embedding model used by embed/recall/remember (env: MNEMON_EMBED_MODEL, default: %s)", embed.DefaultModel))
+	rootCmd.PersistentFlags().StringVar(&embedModel, "embed-model", "",
+		fmt.Sprintf("Ollama embedding model used by embed/recall/remember (env: MNEMON_EMBED_MODEL; falls back to built-in default %q). NOTE: switching to a model with a different output dimension will silently invalidate existing embeddings — backfill after changing.", embed.DefaultModel))
 }
 
-// resolveEmbedModel returns the embedding model to pass into
-// embed.NewClientWithModel. Priority: --embed-model flag > MNEMON_EMBED_MODEL
-// env var > embed.DefaultModel (resolved inside NewClientWithModel).
+// resolveEmbedModel returns the embedding model selector that should be
+// passed to embed.NewClientWithModel.
 //
-// The empty string return value is intentional: it lets the embed package
-// apply its own env/default fallback chain and remain the single source of
-// truth for that resolution.
+// Resolution chain (delegated to NewClientWithModel):
+//
+//	non-empty --embed-model flag > MNEMON_EMBED_MODEL env var > embed.DefaultModel
+//
+// An explicitly empty --embed-model is treated as "unset" and falls through
+// to the env var / built-in default; this matches how the existing --data-dir
+// flag behaves and avoids surprises when a user clears the flag via shell
+// scripting. Env-var resolution happens inside NewClientWithModel at command
+// execution time (not at cmd/init time), so test setups using t.Setenv after
+// package init still work as expected.
 func resolveEmbedModel() string {
 	return embedModel
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&storeName, "store", "", "named memory store (overrides MNEMON_STORE and active file)")
 	rootCmd.PersistentFlags().BoolVar(&readOnly, "readonly", false, "open database in read-only mode (no WAL files, safe for read-only mounts)")
 	rootCmd.PersistentFlags().StringVar(&embedModel, "embed-model", "",
-		fmt.Sprintf("Ollama embedding model used by embed/recall/remember (env: MNEMON_EMBED_MODEL; falls back to built-in default %q). NOTE: switching to a model with a different output dimension will silently invalidate existing embeddings — backfill after changing.", embed.DefaultModel))
+		fmt.Sprintf("Ollama embedding model (env: MNEMON_EMBED_MODEL; default: %s)", embed.DefaultModel))
 }
 
 // resolveEmbedModel returns the embedding model selector that should be

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	"github.com/mnemon-dev/mnemon/internal/embed"
 )
 
 func TestOpenDBRejectsInvalidStoreNameFromEnv(t *testing.T) {
@@ -46,5 +48,57 @@ func TestOpenDBRejectsInvalidStoreNameFromFlag(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid store name") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestResolveEmbedModelChain exercises the full cmd → embed pipeline for the
+// --embed-model flag and MNEMON_EMBED_MODEL env var, mirroring how cobra
+// will hand the value off at runtime. The test runs against
+// embed.NewClientWithModel directly so it does not require a live Ollama.
+func TestResolveEmbedModelChain(t *testing.T) {
+	oldEmbedModel := embedModel
+	t.Cleanup(func() { embedModel = oldEmbedModel })
+
+	cases := []struct {
+		name      string
+		flagValue string
+		envValue  string
+		want      string
+	}{
+		{
+			name:      "flag wins over env",
+			flagValue: "flag-model",
+			envValue:  "env-model",
+			want:      "flag-model",
+		},
+		{
+			name:      "empty flag falls through to env",
+			flagValue: "",
+			envValue:  "env-model",
+			want:      "env-model",
+		},
+		{
+			name:      "empty flag and empty env falls through to built-in default",
+			flagValue: "",
+			envValue:  "",
+			want:      embed.DefaultModel,
+		},
+		{
+			name:      "flag value passes through verbatim",
+			flagValue: "nomic-embed-text-v2-moe:latest",
+			envValue:  "",
+			want:      "nomic-embed-text-v2-moe:latest",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MNEMON_EMBED_MODEL", tc.envValue)
+			embedModel = tc.flagValue
+			client := embed.NewClientWithModel(resolveEmbedModel())
+			if got := client.Model(); got != tc.want {
+				t.Errorf("model resolution: want %q, got %q", tc.want, got)
+			}
+		})
 	}
 }

--- a/internal/embed/ollama.go
+++ b/internal/embed/ollama.go
@@ -30,11 +30,22 @@ type Client struct {
 // It checks MNEMON_EMBED_ENDPOINT, MNEMON_EMBED_MODEL, and
 // MNEMON_EMBED_DIMENSIONS env vars.
 func NewClient() *Client {
+	return NewClientWithModel("")
+}
+
+// NewClientWithModel creates an Ollama embedding client with an explicit
+// model override. Resolution order for the model: explicit argument >
+// MNEMON_EMBED_MODEL env var > DefaultModel. The endpoint and dimensions
+// continue to be resolved from MNEMON_EMBED_ENDPOINT and
+// MNEMON_EMBED_DIMENSIONS env vars.
+func NewClientWithModel(model string) *Client {
 	endpoint := os.Getenv("MNEMON_EMBED_ENDPOINT")
 	if endpoint == "" {
 		endpoint = DefaultEndpoint
 	}
-	model := os.Getenv("MNEMON_EMBED_MODEL")
+	if model == "" {
+		model = os.Getenv("MNEMON_EMBED_MODEL")
+	}
 	if model == "" {
 		model = DefaultModel
 	}

--- a/internal/embed/ollama_test.go
+++ b/internal/embed/ollama_test.go
@@ -59,3 +59,22 @@ func TestNewClientWithModel_DefaultEndpoint(t *testing.T) {
 		t.Errorf("default endpoint: want %q, got %q", DefaultEndpoint, c.Endpoint())
 	}
 }
+
+// TestNewClientWithModel_ExplicitEmptyTreatedAsUnset documents the deliberate
+// choice that --embed-model "" falls through to env-var/default rather than
+// being rejected. This matches how the existing --data-dir flag handles empty
+// strings and avoids surprises when a user clears the flag via shell scripting
+// such as `mnemon --embed-model "$MAYBE_MODEL" ...`.
+func TestNewClientWithModel_ExplicitEmptyTreatedAsUnset(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_MODEL", "env-model")
+	c := NewClientWithModel("")
+	if c.Model() != "env-model" {
+		t.Errorf("explicit empty should fall through to env: want %q, got %q", "env-model", c.Model())
+	}
+
+	t.Setenv("MNEMON_EMBED_MODEL", "")
+	c = NewClientWithModel("")
+	if c.Model() != DefaultModel {
+		t.Errorf("explicit empty + no env should fall through to default: want %q, got %q", DefaultModel, c.Model())
+	}
+}

--- a/internal/embed/ollama_test.go
+++ b/internal/embed/ollama_test.go
@@ -1,0 +1,61 @@
+package embed
+
+import (
+	"testing"
+)
+
+func TestNewClient_DefaultModel(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_MODEL", "")
+	c := NewClient()
+	if c.Model() != DefaultModel {
+		t.Errorf("default model: want %q, got %q", DefaultModel, c.Model())
+	}
+}
+
+func TestNewClient_EnvOverride(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_MODEL", "env-model:latest")
+	c := NewClient()
+	if c.Model() != "env-model:latest" {
+		t.Errorf("env-derived model: want %q, got %q", "env-model:latest", c.Model())
+	}
+}
+
+func TestNewClientWithModel_Explicit(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_MODEL", "")
+	c := NewClientWithModel("explicit-model:v1")
+	if c.Model() != "explicit-model:v1" {
+		t.Errorf("explicit model: want %q, got %q", "explicit-model:v1", c.Model())
+	}
+}
+
+func TestNewClientWithModel_ExplicitWinsOverEnv(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_MODEL", "env-model")
+	c := NewClientWithModel("explicit-model")
+	if c.Model() != "explicit-model" {
+		t.Errorf("explicit-over-env: want %q, got %q", "explicit-model", c.Model())
+	}
+}
+
+func TestNewClientWithModel_EmptyFallsBackToEnv(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_MODEL", "env-model")
+	c := NewClientWithModel("")
+	if c.Model() != "env-model" {
+		t.Errorf("empty-falls-to-env: want %q, got %q", "env-model", c.Model())
+	}
+}
+
+func TestNewClientWithModel_EmptyAndNoEnvFallsBackToDefault(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_MODEL", "")
+	c := NewClientWithModel("")
+	if c.Model() != DefaultModel {
+		t.Errorf("empty-and-no-env: want %q, got %q", DefaultModel, c.Model())
+	}
+}
+
+func TestNewClientWithModel_DefaultEndpoint(t *testing.T) {
+	t.Setenv("MNEMON_EMBED_ENDPOINT", "")
+	c := NewClientWithModel("any-model")
+	if c.Endpoint() != DefaultEndpoint {
+		t.Errorf("default endpoint: want %q, got %q", DefaultEndpoint, c.Endpoint())
+	}
+}


### PR DESCRIPTION
## Summary

Exposes the existing `MNEMON_EMBED_MODEL` env var on the CLI as a global `--embed-model` flag, following the same pattern as `--data-dir` / `MNEMON_DATA_DIR`. The flag applies consistently across `embed`, `recall`, and `remember` so vectors stay comparable.

```
mnemon --embed-model nomic-embed-text-v2-moe:latest embed --all
```

## Motivation

While onboarding mnemon on a real corpus (153 insights, 5+ days of accumulated memory), I noticed every recall returned `"similarity": 0`. `mnemon embed --status` revealed 0% coverage — embeddings had never been run. After running `mnemon embed --all` against the default `nomic-embed-text` (v1, English-only), the multilingual zh-EN content didn't cluster meaningfully because v1 tokenises non-Latin scripts poorly.

The fix locally was to switch to `nomic-embed-text-v2-moe` (768-dim wire-compatible with v1, multilingual, ~100 languages). But there was no CLI flag to point mnemon at it — I had to use an `ollama cp` tag-alias workaround. The env var already existed in `NewClient()` but wasn't surfaced anywhere user-discoverable.

Empirical results on the same 153-insight corpus after switching to v2-moe via the alias trick:

| Query | Result |
|---|---|
| EN: `"Audrey Tang Lagrange point"` | top similarity 0.542 |
| **ZH: `"唐鳳 拉格朗日點"`** | **surfaced a BW column memory with `kw=0.000` + `similarity=0.299`** (pure semantic match — v1 cannot do this) |
| Cross-lingual EN→ZH: `"Tamsui bridge aesthetics sunset"` | surfaced ZH-mixed glossary memory with similarity 0.242 |

## Changes

- `internal/embed/ollama.go`: add `NewClientWithModel(model string)`; `NewClient()` becomes a thin wrapper that delegates with `""` for backward compat. Resolution: explicit > env > `DefaultModel`.
- `cmd/root.go`: add `--embed-model` persistent flag (default empty); add `resolveEmbedModel()` helper. Env-var resolution deferred to `NewClientWithModel` at execution time so tests using `t.Setenv` after package init still work.
- `cmd/embed.go`, `cmd/recall.go`, `cmd/remember.go`: switch from `embed.NewClient()` to `embed.NewClientWithModel(resolveEmbedModel())`.
- `internal/embed/ollama_test.go`: 7 unit tests covering `NewClient` backward compat + `NewClientWithModel` precedence chain, including an explicit test documenting that `--embed-model ""` is treated as "unset, fall through to env/default" (matches existing `--data-dir` behaviour).
- `cmd/root_test.go`: `TestResolveEmbedModelChain` table test exercising the full cmd → embed pipeline.
- `CHANGELOG.md`: Unreleased entry, with note that switching to a different-dim model silently invalidates existing embeddings (backfill required).

## Test plan

- [x] `make unit` (all packages pass)
- [x] `make vet`
- [x] `gofmt -l .` (clean)
- [x] `make build`
- [x] Smoke test: `--embed-model` flag shown in `--help`
- [x] Smoke test: `MNEMON_EMBED_MODEL=foo mnemon embed --status` → `model = foo`
- [x] Smoke test: `mnemon --embed-model bar embed --status` → `model = bar`
- [x] Smoke test: flag wins over env (`MNEMON_EMBED_MODEL=env mnemon --embed-model flag embed --status` → `model = flag`)
- [x] Smoke test: empty flag falls through to env (`MNEMON_EMBED_MODEL=env mnemon --embed-model "" embed --status` → `model = env`)
- [x] Smoke test: no flag + no env → `model = nomic-embed-text`
- [x] Adversarial review (3 rounds via `codex exec`); final round: approve, no findings.

## Notes

- Backward-compatible: existing callers of `embed.NewClient()` see no change in behaviour.
- The 4 prior open issues / closed PRs include #3 (LLM-friendly recall output) which is orthogonal; this PR is the smaller embedding-discoverability win.
- Help line is 104 chars (comparable to existing `--data-dir` at 101 chars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)