### PR TITLE
feat(recall): make default output LLM-friendly with --verbose for full payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 
 - **BREAKING**: `recall` default output is now compact (LLM-friendly).
-  Use `--verbose` (or `--format json`) to restore the previous full
-  payload. The compact format keeps id / content / category /
-  importance / intent / matched_via / confidence / score; signals,
-  timestamps, traversal metadata, and extra fields are dropped from
-  the default and remain available via `--verbose`. (#3)
+  Use `--verbose` to restore the previous full payload. The compact
+  format keeps id / content / category / importance / intent /
+  matched_via / confidence / score; signals, timestamps, traversal
+  metadata, and extra fields are dropped from the default and remain
+  available via `--verbose`. (#3)
 
 ### Added
 
 - `--verbose` flag on `recall` to output the full RecallResponse.
-- `--format` flag on `recall` accepting `compact` (default), `verbose`,
-  or `json` (alias for verbose).
 
 ## [0.1.8] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING**: `recall` default output is now compact (LLM-friendly).
+  Use `--verbose` (or `--format json`) to restore the previous full
+  payload. The compact format keeps id / content / category /
+  importance / intent / matched_via / confidence / score; signals,
+  timestamps, traversal metadata, and extra fields are dropped from
+  the default and remain available via `--verbose`. (#3)
+
+### Added
+
+- `--verbose` flag on `recall` to output the full RecallResponse.
+- `--format` flag on `recall` accepting `compact` (default), `verbose`,
+  or `json` (alias for verbose).
+
 ## [0.1.8] - 2026-05-24
 
 ### Added

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -77,6 +77,7 @@ func roundScore(s float64) float64 {
 func toCompact(resp search.RecallResponse) compactResponse {
 	results := make([]compactResult, 0, len(resp.Results))
 	for _, r := range resp.Results {
+		rounded := roundScore(r.Score)
 		cr := compactResult{
 			ID:         r.Insight.ID,
 			Content:    r.Insight.Content,
@@ -84,8 +85,8 @@ func toCompact(resp search.RecallResponse) compactResponse {
 			Importance: r.Insight.Importance,
 			Intent:     string(r.Intent),
 			MatchedVia: r.Via,
-			Confidence: confidenceLabel(r.Score),
-			Score:      roundScore(r.Score),
+			Confidence: confidenceLabel(rounded),
+			Score:      rounded,
 		}
 		results = append(results, cr)
 	}

--- a/cmd/recall.go
+++ b/cmd/recall.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -20,7 +21,79 @@ var (
 	recBasic    bool
 	recSmart    bool //nolint:unused // deprecated: smart is now the default; kept for backward compat
 	recIntent   string
+	recVerbose  bool
 )
+
+// compactResult is the LLM-friendly projection of a recall result.
+// It drops signals, timestamps, traversal metadata, and other debug fields
+// that add noise for agent consumption.
+type compactResult struct {
+	ID         string  `json:"id"`
+	Content    string  `json:"content"`
+	Category   string  `json:"category,omitempty"`
+	Importance int     `json:"importance,omitempty"`
+	Intent     string  `json:"intent"`
+	MatchedVia string  `json:"matched_via,omitempty"`
+	Confidence string  `json:"confidence"`
+	Score      float64 `json:"score"`
+}
+
+// compactResponse wraps compact results with an optional hint.
+type compactResponse struct {
+	Results []compactResult `json:"results"`
+	Hint    string          `json:"hint,omitempty"`
+}
+
+// confidenceLowMax / confidenceMediumMax bucket the recall score into
+// low / medium / high labels for agent consumption. The score is the
+// weighted sum of normalized signals (keyword + entity + similarity +
+// graph), so it is not a calibrated probability. The current cutoffs
+// are chosen empirically and may need tuning once we have a larger
+// sample of real recall traces; until then the raw score is also
+// exposed for callers that need finer control.
+const (
+	confidenceLowMax    = 0.25
+	confidenceMediumMax = 0.6
+)
+
+// confidenceLabel maps a numeric score to a discrete confidence bucket.
+func confidenceLabel(score float64) string {
+	switch {
+	case score < confidenceLowMax:
+		return "low"
+	case score < confidenceMediumMax:
+		return "medium"
+	default:
+		return "high"
+	}
+}
+
+// roundScore rounds a float to 3 decimal places (half-away-from-zero).
+func roundScore(s float64) float64 {
+	return math.Round(s*1000) / 1000
+}
+
+// toCompact projects a full RecallResponse into the compact LLM-friendly shape.
+func toCompact(resp search.RecallResponse) compactResponse {
+	results := make([]compactResult, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		cr := compactResult{
+			ID:         r.Insight.ID,
+			Content:    r.Insight.Content,
+			Category:   string(r.Insight.Category),
+			Importance: r.Insight.Importance,
+			Intent:     string(r.Intent),
+			MatchedVia: r.Via,
+			Confidence: confidenceLabel(r.Score),
+			Score:      roundScore(r.Score),
+		}
+		results = append(results, cr)
+	}
+	return compactResponse{
+		Results: results,
+		Hint:    resp.Meta.Hint,
+	}
+}
 
 var recallCmd = &cobra.Command{
 	Use:   "recall [keyword]",
@@ -43,7 +116,7 @@ var recallCmd = &cobra.Command{
 		enc.SetIndent("", "  ")
 
 		if recBasic {
-			// Legacy SQL LIKE recall
+			// Legacy SQL LIKE recall (not affected by format flags)
 			results, err := db.QueryInsights(store.QueryFilter{
 				Keyword:  keyword,
 				Category: recCategory,
@@ -78,7 +151,7 @@ var recallCmd = &cobra.Command{
 			queryVec, _ = ec.Embed(keyword)
 		}
 
-		// Extract query entities at cmd layer (avoid graph→search circular dep)
+		// Extract query entities at cmd layer (avoid graph->search circular dep)
 		queryEntities := graph.ExtractEntities(keyword)
 
 		resp, err := search.IntentAwareRecall(db, keyword, queryVec, queryEntities, recLimit, intentOverride)
@@ -89,7 +162,11 @@ var recallCmd = &cobra.Command{
 			_ = db.IncrementAccessCount(r.Insight.ID)
 		}
 		db.LogOp("recall", "", fmt.Sprintf("q=%s hits=%d", keyword, len(resp.Results)))
-		return enc.Encode(resp)
+
+		if recVerbose {
+			return enc.Encode(resp)
+		}
+		return enc.Encode(toCompact(resp))
 	},
 }
 
@@ -101,5 +178,6 @@ func init() {
 	recallCmd.Flags().BoolVar(&recSmart, "smart", false, "deprecated: smart is now the default")
 	_ = recallCmd.Flags().MarkHidden("smart")
 	recallCmd.Flags().StringVar(&recIntent, "intent", "", "override intent (WHY|WHEN|ENTITY|GENERAL)")
+	recallCmd.Flags().BoolVar(&recVerbose, "verbose", false, "output full recall response (signals, meta, timestamps)")
 	rootCmd.AddCommand(recallCmd)
 }

--- a/cmd/recall_test.go
+++ b/cmd/recall_test.go
@@ -207,6 +207,44 @@ func TestRecall_ScoreRoundedToThreeDecimals(t *testing.T) {
 	}
 }
 
+func TestRecall_CompactProjection_ConfidenceMatchesRoundedScore(t *testing.T) {
+	// Verify that the confidence label is derived from the rounded score,
+	// not the raw score. This matters at bucket boundaries where rounding
+	// can cross a cutoff.
+	cases := []struct {
+		rawScore  float64
+		wantScore float64
+		wantLabel string
+	}{
+		{0.5996, 0.6, "high"},     // boundary: rounding crosses 0.6 cutoff
+		{0.2496, 0.25, "medium"},  // boundary: rounding crosses 0.25 cutoff
+		{0.5994, 0.599, "medium"}, // just below boundary, no crossing
+	}
+
+	for _, tc := range cases {
+		resp := search.RecallResponse{
+			Results: []search.RecallResult{
+				{
+					Insight: &model.Insight{
+						ID:      "test-id",
+						Content: "test content",
+					},
+					Score:  tc.rawScore,
+					Intent: search.IntentGeneral,
+				},
+			},
+		}
+		compact := toCompact(resp)
+		r := compact.Results[0]
+		if r.Score != tc.wantScore {
+			t.Errorf("rawScore=%f: want Score=%f, got %f", tc.rawScore, tc.wantScore, r.Score)
+		}
+		if r.Confidence != tc.wantLabel {
+			t.Errorf("rawScore=%f: want Confidence=%q, got %q", tc.rawScore, tc.wantLabel, r.Confidence)
+		}
+	}
+}
+
 func TestRecall_CompactProjection_EmptyResults(t *testing.T) {
 	resp := search.RecallResponse{
 		Results: []search.RecallResult{},

--- a/cmd/recall_test.go
+++ b/cmd/recall_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mnemon-dev/mnemon/internal/model"
+	"github.com/mnemon-dev/mnemon/internal/search"
+)
+
+func makeTestRecallResponse() search.RecallResponse {
+	return search.RecallResponse{
+		Results: []search.RecallResult{
+			{
+				Insight: &model.Insight{
+					ID:          "550e8400-e29b-41d4-a716-446655440000",
+					Content:     "User prefers Qdrant for vector DB",
+					Category:    model.CategoryPreference,
+					Importance:  4,
+					Tags:        []string{"tool", "db"},
+					Entities:    []string{"Qdrant"},
+					Source:      "agent",
+					AccessCount: 2,
+					CreatedAt:   time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+					UpdatedAt:   time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+				},
+				Score:  0.84217,
+				Intent: search.IntentGeneral,
+				Via:    "keyword",
+				Signals: search.SignalScores{
+					Keyword:    0.6,
+					Entity:     0.2,
+					Similarity: 0.0,
+					Graph:      0.04,
+				},
+			},
+			{
+				Insight: &model.Insight{
+					ID:          "660e8400-e29b-41d4-a716-446655440001",
+					Content:     "Chose Qdrant because of Rust performance",
+					Category:    model.CategoryDecision,
+					Importance:  5,
+					Tags:        []string{"architecture"},
+					Entities:    []string{"Qdrant", "Rust"},
+					Source:      "user",
+					AccessCount: 0,
+					CreatedAt:   time.Date(2026, 1, 14, 8, 0, 0, 0, time.UTC),
+					UpdatedAt:   time.Date(2026, 1, 14, 8, 0, 0, 0, time.UTC),
+				},
+				Score:  0.55432,
+				Intent: search.IntentGeneral,
+				Via:    "graph",
+				Signals: search.SignalScores{
+					Keyword:    0.3,
+					Entity:     0.1,
+					Similarity: 0.0,
+					Graph:      0.15,
+				},
+			},
+		},
+		Meta: search.RecallMeta{
+			Intent:       search.IntentGeneral,
+			IntentSource: "auto",
+			AnchorCount:  3,
+			Traversed:    12,
+			Hint:         "sparse_results",
+		},
+	}
+}
+
+func TestRecall_CompactProjection_PreservesContentAndIntent(t *testing.T) {
+	resp := makeTestRecallResponse()
+	compact := toCompact(resp)
+
+	if len(compact.Results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(compact.Results))
+	}
+
+	r := compact.Results[0]
+	if r.Content != "User prefers Qdrant for vector DB" {
+		t.Errorf("content: got %q", r.Content)
+	}
+	if r.Intent != "GENERAL" {
+		t.Errorf("intent: got %q", r.Intent)
+	}
+	if r.Category != "preference" {
+		t.Errorf("category: got %q", r.Category)
+	}
+	if r.Importance != 4 {
+		t.Errorf("importance: got %d", r.Importance)
+	}
+}
+
+func TestRecall_CompactProjection_DropsSignalsAndTimestamps(t *testing.T) {
+	resp := makeTestRecallResponse()
+	compact := toCompact(resp)
+
+	// Marshal to JSON and verify that dropped fields are absent.
+	data, err := json.Marshal(compact)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	raw := string(data)
+
+	absent := []string{
+		`"signals"`,
+		`"meta"`,
+		`"created_at"`,
+		`"updated_at"`,
+		`"access_count"`,
+		`"tags"`,
+		`"entities"`,
+		`"source"`,
+		`"anchor_count"`,
+		`"traversed"`,
+	}
+	for _, sub := range absent {
+		if strings.Contains(raw, sub) {
+			t.Errorf("compact JSON should not contain %s, got: %s", sub, raw)
+		}
+	}
+}
+
+func TestRecall_CompactProjection_PreservesHint(t *testing.T) {
+	resp := makeTestRecallResponse()
+	compact := toCompact(resp)
+
+	if compact.Hint != "sparse_results" {
+		t.Errorf("hint: want sparse_results, got %q", compact.Hint)
+	}
+
+	// Empty hint case
+	resp.Meta.Hint = ""
+	compact = toCompact(resp)
+	if compact.Hint != "" {
+		t.Errorf("empty hint: want empty, got %q", compact.Hint)
+	}
+}
+
+func TestRecall_CompactProjection_PreservesFullID(t *testing.T) {
+	resp := makeTestRecallResponse()
+	compact := toCompact(resp)
+
+	expectedID := "550e8400-e29b-41d4-a716-446655440000"
+	if compact.Results[0].ID != expectedID {
+		t.Errorf("ID should be full UUID: want %q, got %q", expectedID, compact.Results[0].ID)
+	}
+}
+
+func TestRecall_CompactProjection_MatchedVia(t *testing.T) {
+	resp := makeTestRecallResponse()
+	compact := toCompact(resp)
+
+	if compact.Results[0].MatchedVia != "keyword" {
+		t.Errorf("matched_via[0]: want keyword, got %q", compact.Results[0].MatchedVia)
+	}
+	if compact.Results[1].MatchedVia != "graph" {
+		t.Errorf("matched_via[1]: want graph, got %q", compact.Results[1].MatchedVia)
+	}
+}
+
+func TestRecall_ConfidenceLabel_Buckets(t *testing.T) {
+	cases := []struct {
+		score float64
+		want  string
+	}{
+		{0.0, "low"},
+		{0.1, "low"},
+		{0.24, "low"},
+		{0.25, "medium"},
+		{0.3, "medium"},
+		{0.59, "medium"},
+		{0.6, "high"},
+		{0.842, "high"},
+		{1.0, "high"},
+		{1.5, "high"},
+	}
+
+	for _, tc := range cases {
+		got := confidenceLabel(tc.score)
+		if got != tc.want {
+			t.Errorf("confidenceLabel(%f): want %q, got %q", tc.score, tc.want, got)
+		}
+	}
+}
+
+func TestRecall_ScoreRoundedToThreeDecimals(t *testing.T) {
+	cases := []struct {
+		input float64
+		want  float64
+	}{
+		{0.84217, 0.842},
+		{0.55432, 0.554},
+		{0.1, 0.1},
+		{0.9999, 1.0},
+		{0.0005, 0.001},
+		{0.0004, 0.0},
+	}
+
+	for _, tc := range cases {
+		got := roundScore(tc.input)
+		if got != tc.want {
+			t.Errorf("roundScore(%f): want %f, got %f", tc.input, tc.want, got)
+		}
+	}
+}
+
+func TestRecall_CompactProjection_EmptyResults(t *testing.T) {
+	resp := search.RecallResponse{
+		Results: []search.RecallResult{},
+		Meta: search.RecallMeta{
+			Intent:       search.IntentGeneral,
+			IntentSource: "auto",
+			AnchorCount:  0,
+			Traversed:    0,
+			Hint:         "sparse_results",
+		},
+	}
+	compact := toCompact(resp)
+	if len(compact.Results) != 0 {
+		t.Errorf("want 0 results, got %d", len(compact.Results))
+	}
+	if compact.Hint != "sparse_results" {
+		t.Errorf("hint should be preserved even with empty results")
+	}
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -61,8 +61,16 @@ mnemon remember "Chose Qdrant over Milvus for vector search" \
 # Skip duplicate/conflict detection
 mnemon remember "Raw note" --no-diff
 
-# Recall — intent-aware graph-enhanced retrieval (default)
+# Recall — intent-aware graph-enhanced retrieval (default: compact output)
 mnemon recall "vector database" --limit 10
+
+# Recall with full verbose output (signals, meta, timestamps)
+mnemon recall "vector database" --verbose
+
+# Recall with explicit format selection
+mnemon recall "vector database" --format compact   # default
+mnemon recall "vector database" --format verbose   # same as --verbose
+mnemon recall "vector database" --format json      # alias for verbose
 
 # Recall with explicit intent override
 mnemon recall "why did we choose Qdrant" --intent WHY
@@ -101,6 +109,13 @@ mnemon forget <id>
 | `--cat` | | Filter by category |
 | `--source` | | Filter by source |
 | `--basic` | `false` | Use simple SQL LIKE matching instead of smart recall |
+| `--verbose` | `false` | Output full recall response (signals, meta, timestamps) |
+| `--format` | `compact` | Output format: `compact`, `verbose`, or `json` (alias for verbose) |
+
+The default compact output is optimized for LLM/agent consumption. It includes
+`id`, `content`, `category`, `importance`, `intent`, `matched_via`, `confidence`,
+and `score`. Use `--verbose` or `--format verbose` to restore the full payload
+with signals, traversal metadata, and timestamps.
 
 ### Graph Operations
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -67,11 +67,6 @@ mnemon recall "vector database" --limit 10
 # Recall with full verbose output (signals, meta, timestamps)
 mnemon recall "vector database" --verbose
 
-# Recall with explicit format selection
-mnemon recall "vector database" --format compact   # default
-mnemon recall "vector database" --format verbose   # same as --verbose
-mnemon recall "vector database" --format json      # alias for verbose
-
 # Recall with explicit intent override
 mnemon recall "why did we choose Qdrant" --intent WHY
 
@@ -110,12 +105,12 @@ mnemon forget <id>
 | `--source` | | Filter by source |
 | `--basic` | `false` | Use simple SQL LIKE matching instead of smart recall |
 | `--verbose` | `false` | Output full recall response (signals, meta, timestamps) |
-| `--format` | `compact` | Output format: `compact`, `verbose`, or `json` (alias for verbose) |
 
 The default compact output is optimized for LLM/agent consumption. It includes
 `id`, `content`, `category`, `importance`, `intent`, `matched_via`, `confidence`,
-and `score`. Use `--verbose` or `--format verbose` to restore the full payload
-with signals, traversal metadata, and timestamps.
+and `score`. Use `--verbose` to restore the full payload with signals, traversal
+metadata, and timestamps. The confidence label is only emitted in compact mode;
+verbose payloads return the raw score for callers that prefer their own thresholds.
 
 ### Graph Operations
 

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -216,14 +216,23 @@ assert_jq "importance is 4"        "$OUT" '.importance' '4'
 assert_contains "tags include tool" "$OUT" '"tool"'
 assert_contains "entities has Qdrant" "$OUT" '"Qdrant"'
 
-step "recall — keyword search"
+step "recall — keyword search (compact default)"
 OUT=$($M --data-dir "$TESTDIR" recall "Qdrant")
 show_json "$OUT" 10
 assert_contains "found Qdrant insight" "$OUT" "User prefers Qdrant"
+assert_contains "compact has confidence" "$OUT" '"confidence"'
+assert_not_contains "compact omits signals" "$OUT" '"signals"'
+assert_not_contains "compact omits anchor_count" "$OUT" '"anchor_count"'
 
-step "recall — no match returns sparse hint"
+step "recall — no match returns sparse hint (compact)"
 OUT=$($M --data-dir "$TESTDIR" recall "nonexistent_xyz")
 assert_contains "sparse hint" "$OUT" "sparse_results"
+
+step "recall --verbose — full payload"
+OUT=$($M --data-dir "$TESTDIR" recall "Qdrant" --verbose)
+assert_contains "verbose has meta" "$OUT" '"meta"'
+assert_contains "verbose has signals" "$OUT" '"signals"'
+assert_contains "verbose has anchor_count" "$OUT" '"anchor_count"'
 
 step "status — statistics"
 OUT=$($M --data-dir "$TESTDIR" status)
@@ -354,7 +363,7 @@ ID_Z=$(extract_id "$OUT_Z")
 assert_jq_gte "Z has causal edge to Y" "$OUT_Z" '.edges_created.causal' '1'
 
 step "multi-level traversal — smart recall finds depth-2 node"
-OUT=$($M --data-dir "$TESTDIR3" recall "why Alpha service routing" --smart)
+OUT=$($M --data-dir "$TESTDIR3" recall "why Alpha service routing" --smart --verbose)
 echo -e "    ${DIM}intent: $(echo "$OUT" | jq -r '.results[0].intent // "N/A"')  results: $(echo "$OUT" | jq '.results | length')${RESET}"
 echo "$OUT" | jq -r '.results[] | "    \(.via)\t\(.score | tostring | .[:6])\t\(.insight.content[:50])"' 2>/dev/null
 assert_contains "finds anchor X (Alpha)" "$OUT" "$ID_X"
@@ -362,18 +371,18 @@ assert_contains "finds depth-1 Y (routing)" "$OUT" "$ID_Y"
 assert_contains "finds depth-2 Z (caching)" "$OUT" "$ID_Z"
 
 step "smart recall — WHY intent"
-OUT=$($M --data-dir "$TESTDIR2" recall "why did we choose Qdrant" --smart)
+OUT=$($M --data-dir "$TESTDIR2" recall "why did we choose Qdrant" --smart --verbose)
 echo -e "    ${DIM}intent: $(echo "$OUT" | jq -r '.results[0].intent // "N/A"')  results: $(echo "$OUT" | jq '.results | length')${RESET}"
 assert_contains "intent is WHY" "$OUT" '"WHY"'
 assert_contains "finds Qdrant insight" "$OUT" "Qdrant"
 
 step "smart recall — WHEN intent"
-OUT=$($M --data-dir "$TESTDIR2" recall "when did we choose vector db" --smart)
+OUT=$($M --data-dir "$TESTDIR2" recall "when did we choose vector db" --smart --verbose)
 echo -e "    ${DIM}intent: $(echo "$OUT" | jq -r '.results[0].intent // "N/A"')  results: $(echo "$OUT" | jq '.results | length')${RESET}"
 assert_contains "intent is WHEN" "$OUT" '"WHEN"'
 
 step "smart recall — graph augments results"
-OUT=$($M --data-dir "$TESTDIR2" recall "why Qdrant performance" --smart)
+OUT=$($M --data-dir "$TESTDIR2" recall "why Qdrant performance" --smart --verbose)
 COUNT=$(echo "$OUT" | jq '.results | length')
 TOTAL=$((TOTAL + 1))
 if [ "$COUNT" -ge 2 ]; then
@@ -442,7 +451,7 @@ OUT=$($M --data-dir "$TESTDIR5" link "$ID_S1" "nonexistent-id-000" --type semant
 assert_contains "rejects missing insight" "$OUT" "not found"
 
 step "smart recall — semantic edges participate in traversal"
-OUT=$($M --data-dir "$TESTDIR5" recall "Go CLI" --smart)
+OUT=$($M --data-dir "$TESTDIR5" recall "Go CLI" --smart --verbose)
 COUNT=$(echo "$OUT" | jq '.results | length')
 TOTAL=$((TOTAL + 1))
 if [ "$COUNT" -ge 2 ]; then
@@ -595,7 +604,7 @@ if [ "$OLLAMA_OK" = "true" ]; then
   assert_jq "all embedded" "$OUT" '.coverage' '100%'
 
   step "recall --smart — uses hybrid search with embeddings"
-  OUT=$($M --data-dir "$TESTDIR7" recall "embedding test" --smart)
+  OUT=$($M --data-dir "$TESTDIR7" recall "embedding test" --smart --verbose)
   COUNT=$(echo "$OUT" | jq '.results | length')
   TOTAL=$((TOTAL + 1))
   if [ "$COUNT" -ge 1 ]; then
@@ -787,16 +796,16 @@ banner "Milestone 11: Smart Recall Reranking + Signals"
 # ══════════════════════════════════════════════════════════════════════
 
 step "smart recall — --intent override"
-OUT=$($M --data-dir "$TESTDIR3" recall "Alpha service" --smart --intent WHY)
+OUT=$($M --data-dir "$TESTDIR3" recall "Alpha service" --smart --intent WHY --verbose)
 assert_jq "intent is WHY" "$OUT" '.meta.intent' 'WHY'
 assert_jq "intent_source is override" "$OUT" '.meta.intent_source' 'override'
 
 step "smart recall — auto-detected intent source"
-OUT=$($M --data-dir "$TESTDIR3" recall "why Alpha service routing" --smart)
+OUT=$($M --data-dir "$TESTDIR3" recall "why Alpha service routing" --smart --verbose)
 assert_jq "intent_source is auto" "$OUT" '.meta.intent_source' 'auto'
 
 step "smart recall — signals metadata present"
-OUT=$($M --data-dir "$TESTDIR3" recall "Alpha service routing" --smart)
+OUT=$($M --data-dir "$TESTDIR3" recall "Alpha service routing" --smart --verbose)
 FIRST=$(echo "$OUT" | jq '.results[0]')
 assert_contains "has signals" "$FIRST" '"signals"'
 assert_contains "has keyword signal" "$FIRST" '"keyword"'


### PR DESCRIPTION
## Summary

Default \`recall\` output is now a compact, LLM-friendly projection that keeps only the fields an agent actually needs. The previous full payload (signals, timestamps, traversal metadata) is still available via \`--verbose\`.

This significantly reduces per-result token cost while preserving everything needed for downstream commands (\`forget\`, \`link\`) and agent decision-making.

## Motivation

Reported in #3: the default \`recall\` JSON dumps signals, timestamps, access counts, traversal stats, and other debug metadata that bloat context windows and dilute LLM attention. As @Grivn noted in the issue thread:

> Main thing is: default \`recall\` should be lighter for agents, while the current full/debug payload should still be available somehow.

A typical \`recall\` result currently carries ~15 fields per entry (id, content, category, importance, tags, entities, source, access_count, created_at, updated_at, score, intent, via, signals.{keyword, entity, similarity, graph}). The compact shape keeps 8 (id, content, category, importance, intent, matched_via, confidence, score). The dropped fields stay one flag away.

## What changed

**\`cmd/recall.go\`** (+84)
- Added \`compactResult\` / \`compactResponse\` structs defining the LLM-friendly shape
- Added \`confidenceLabel()\` with named constants (\`confidenceLowMax = 0.25\`, \`confidenceMediumMax = 0.6\`) to bucket raw scores into \`low\` / \`medium\` / \`high\`. The cutoffs are empirical and the constants carry a comment explaining they may need tuning once we have a larger sample of real recall traces
- Added \`roundScore()\` to round scores to 3 decimal places (half-away-from-zero)
- Added \`toCompact()\` projection function
- Added \`--verbose\` flag; when set, the full \`RecallResponse\` is emitted unchanged
- \`--basic\` path is untouched

**\`cmd/recall_test.go\`** (new, +228)
- 8 unit tests covering: content/intent/category preservation, JSON-level absence of dropped fields (signals, meta, timestamps, tags, entities, source, access_count, anchor_count, traversed), hint passthrough, full UUID preservation, \`matched_via\` mapping, confidence bucket boundaries, score rounding edge cases, empty-results handling

**\`docs/USAGE.md\`** (+12)
- Documented \`--verbose\` flag and the new default compact shape under the Recall section
- Noted that \`confidence\` is only emitted in compact mode (verbose returns raw score for callers that prefer their own thresholds)

**\`CHANGELOG.md\`** (+13)
- \`[Unreleased]\` entry documenting the BREAKING change and the new \`--verbose\` flag

**\`scripts/e2e_test.sh\`** (+31/-15)
- Existing assertions that depend on full payload fields now pass \`--verbose\`
- New assertions: compact has \`confidence\`, compact omits \`signals\`, compact omits \`anchor_count\`

## ⚠️ BREAKING CHANGE

The default JSON shape of \`recall\` (non-\`--basic\`) has changed. Scripts or SDKs that parse the old response need to either:

1. Add \`--verbose\` to their invocation to restore the previous full shape, **or**
2. Migrate to the new compact shape (fields: \`id\`, \`content\`, \`category\`, \`importance\`, \`intent\`, \`matched_via\`, \`confidence\`, \`score\`, top-level \`hint\`)

The \`--basic\` path is unchanged.

## Out of scope / Design notes

- No \`--format\` flag introduced. A single \`--verbose\` toggle covers the two real use cases (agent vs. debug/scripting). A richer \`--format\` can be added later if yaml/csv/text output is actually requested.
- \`--basic\` path left as-is. It serves as a SQL LIKE debugging escape hatch and has its own consumers.
- \`internal/search\` package untouched. The projection is a presentation concern handled at the cmd layer; keeping the engine stable avoids ripple effects.
- \`confidence\` only appears in compact mode. Verbose already exposes the raw score, so consumers that need custom thresholds can compute their own labels.

## Test plan

- [x] \`gofmt -l .\` clean
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` succeeds
- [x] \`go test ./...\` all pass
- [x] \`bash scripts/e2e_test.sh\` passes (146/147; the single failure is a pre-existing \`MNEMON_STORE\` env path test on Windows, unrelated to this PR)
- [x] Manual verification: default compact output, \`--verbose\` restores old shape, \`--basic\` unaffected, IDs are full-length UUIDs (usable with \`forget\`)

Closes #3