### PR TITLE
fix(claude): use valid memory subagent type

### DIFF
--- a/docs/diagrams/mnemon-architecture.drawio
+++ b/docs/diagrams/mnemon-architecture.drawio
@@ -1114,7 +1114,7 @@
         <mxCell id="i_c2" value="&lt;b&gt;Remember Decision Tree&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Step 1: directive/reasoning/state?&lt;br&gt;Step 2: overlap check (update/replace/create)&lt;br&gt;Step 3: cost-benefit evaluation&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#E6FFE6;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="290" y="400" width="260" height="75" as="geometry"/>
         </mxCell>
-        <mxCell id="i_c3" value="&lt;b&gt;Sub-Agent Delegation&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Delegate to Task sub-agent&lt;br&gt;(Bash type, Sonnet model)&lt;br&gt;Only provide WHAT to store&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#E6FFE6;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
+        <mxCell id="i_c3" value="&lt;b&gt;Sub-Agent Delegation&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px&quot;&gt;Delegate to Task sub-agent&lt;br&gt;(general-purpose type, Sonnet model)&lt;br&gt;Only provide WHAT to store&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#E6FFE6;strokeColor=#82b366;fontSize=10;" vertex="1" parent="1">
           <mxGeometry x="580" y="400" width="210" height="75" as="geometry"/>
         </mxCell>
         <mxCell id="i_c4" value="&lt;font style=&quot;font-size:9px&quot;&gt;&lt;b&gt;Do NOT remember:&lt;/b&gt;&lt;br&gt;operational tasks,&lt;br&gt;public knowledge,&lt;br&gt;info in git&lt;/font&gt;" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#f8cecc;strokeColor=#b85450;fontSize=9;" vertex="1" parent="1">

--- a/internal/setup/assets/claude/guide.md
+++ b/internal/setup/assets/claude/guide.md
@@ -53,7 +53,7 @@ Aim for a rough distribution: ~20% at 4-5, ~50% at 2-3, ~30% at 1.
 Avoid defaulting everything to 4-5 — that defeats the scoring system.
 
 **What to store**: both conclusions AND context. Prefer storing a little too much over missing something useful.
-**How to store**: delegate to a Task sub-agent (`subagent_type="Bash"`, `model="sonnet"`).
+**How to store**: delegate to a Task sub-agent (`subagent_type="general-purpose"`, `model="sonnet"`).
 Only provide what to store — content, category, importance, entities, and create/update intent.
 The sub-agent will read the mnemon skill and execute the correct commands itself.
 


### PR DESCRIPTION
## Summary
- replace the invalid Claude memory `Bash` subagent type with the built-in `general-purpose` type
- update the architecture diagram text to match the setup guidance

Fixes #39

## Validation
- `rg -n 'subagent_type="Bash"|Bash type' internal/setup/assets/claude docs/diagrams`\n- `go build -o mnemon .`