### PR TITLE
fix(setup): scope prompt files to MNEMON_DATA_DIR

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -189,13 +189,15 @@ func installClaudeCode(env *setup.Environment) error {
 		setup.StatusOK(0, 0, "Skill", path)
 	}
 
-	// Phase 2: Prompt files (guide.md + skill.md → ~/.mnemon/prompt/)
+	// Phase 2: Prompt files (guide.md + skill.md → PromptDir)
 	fmt.Println("\n[2/3] Prompts")
+	var promptPath string
 	if path, err := setup.WritePromptFiles(); err != nil {
 		setup.StatusError(0, 0, "Prompts", err)
 		return err
 	} else {
 		setup.StatusOK(0, 0, "Prompts", path)
+		promptPath = path
 	}
 
 	if path, err := setup.ClaudeWriteHook(configDir, "prime.sh", assets.ClaudePrimeHook); err != nil {
@@ -253,10 +255,10 @@ func installClaudeCode(env *setup.Environment) error {
 	fmt.Println()
 	fmt.Println("Setup complete!")
 	fmt.Printf("  Hooks   %s\n", strings.Join(hookNames, ", "))
-	fmt.Printf("  Prompts ~/.mnemon/prompt/ (guide.md, skill.md)\n")
+	fmt.Printf("  Prompts %s/ (guide.md, skill.md)\n", promptPath)
 	fmt.Println()
 	fmt.Println("Start a new Claude Code session to activate.")
-	fmt.Println("Edit ~/.mnemon/prompt/guide.md to customize behavior.")
+	fmt.Printf("Edit %s/guide.md to customize behavior.\n", promptPath)
 	fmt.Println("Run 'mnemon setup --eject' to remove.")
 
 	return nil
@@ -316,11 +318,13 @@ func installCodex(env *setup.Environment) error {
 	}
 
 	fmt.Println("\n[2/4] Prompts")
+	var promptPath string
 	if path, err := setup.WritePromptFiles(); err != nil {
 		setup.StatusError(0, 0, "Prompts", err)
 		return err
 	} else {
 		setup.StatusOK(0, 0, "Prompts", path)
+		promptPath = path
 	}
 
 	fmt.Println("\n[3/4] Hooks")
@@ -355,7 +359,7 @@ func installCodex(env *setup.Environment) error {
 	fmt.Println("Setup complete!")
 	fmt.Printf("  Skill   %s/skills/mnemon/SKILL.md\n", configDir)
 	fmt.Printf("  Hooks   %s/hooks.json (SessionStart, UserPromptSubmit, Stop)\n", configDir)
-	fmt.Printf("  Prompts ~/.mnemon/prompt/ (guide.md, skill.md)\n")
+	fmt.Printf("  Prompts %s/ (guide.md, skill.md)\n", promptPath)
 	fmt.Println()
 	fmt.Println("Start a new Codex session to activate.")
 	fmt.Println("Run 'mnemon setup --eject --target codex' to remove.")
@@ -397,13 +401,15 @@ func installOpenClaw(env *setup.Environment) error {
 		setup.StatusOK(0, 0, "Skill", path)
 	}
 
-	// Phase 2: Prompt files (guide.md + skill.md → ~/.mnemon/prompt/)
+	// Phase 2: Prompt files (guide.md + skill.md → PromptDir)
 	fmt.Println("\n[2/4] Prompts")
+	var promptPath string
 	if path, err := setup.WritePromptFiles(); err != nil {
 		setup.StatusError(0, 0, "Prompts", err)
 		return err
 	} else {
 		setup.StatusOK(0, 0, "Prompts", path)
+		promptPath = path
 	}
 
 	// Phase 3: Internal hook (agent:bootstrap → inject guide)
@@ -448,10 +454,10 @@ func installOpenClaw(env *setup.Environment) error {
 	fmt.Printf("  Skill   %s/skills/mnemon/SKILL.md\n", configDir)
 	fmt.Printf("  Hook    %s/hooks/mnemon-prime/ (agent:bootstrap)\n", configDir)
 	fmt.Printf("  Plugin  %s/extensions/mnemon/ (hooks: %s)\n", configDir, strings.Join(hookNames, ", "))
-	fmt.Printf("  Prompts ~/.mnemon/prompt/ (guide.md, skill.md)\n")
+	fmt.Printf("  Prompts %s/ (guide.md, skill.md)\n", promptPath)
 	fmt.Println()
 	fmt.Println("Restart the OpenClaw gateway to activate.")
-	fmt.Println("Edit ~/.mnemon/prompt/guide.md to customize behavior.")
+	fmt.Printf("Edit %s/guide.md to customize behavior.\n", promptPath)
 	fmt.Println("Run 'mnemon setup --eject' to remove.")
 
 	return nil
@@ -513,23 +519,25 @@ func installNanobot(env *setup.Environment) error {
 		setup.StatusOK(0, 0, "Skill", path)
 	}
 
-	// Phase 2: Prompt files (guide.md + skill.md → ~/.mnemon/prompt/)
+	// Phase 2: Prompt files (guide.md + skill.md → PromptDir)
 	fmt.Println("\n[2/2] Prompts")
+	var promptPath string
 	if path, err := setup.WritePromptFiles(); err != nil {
 		setup.StatusError(0, 0, "Prompts", err)
 		return err
 	} else {
 		setup.StatusOK(0, 0, "Prompts", path)
+		promptPath = path
 	}
 
 	// Summary
 	fmt.Println()
 	fmt.Println("Setup complete!")
 	fmt.Printf("  Skill   %s/skills/mnemon/SKILL.md\n", configDir)
-	fmt.Printf("  Prompts ~/.mnemon/prompt/ (guide.md, skill.md)\n")
+	fmt.Printf("  Prompts %s/ (guide.md, skill.md)\n", promptPath)
 	fmt.Println()
 	fmt.Println("Restart Nanobot to activate the mnemon skill.")
-	fmt.Println("Edit ~/.mnemon/prompt/guide.md to customize behavior.")
+	fmt.Printf("Edit %s/guide.md to customize behavior.\n", promptPath)
 	fmt.Println("Run 'mnemon setup --eject' to remove.")
 
 	return nil

--- a/internal/setup/assets/claude/prime.sh
+++ b/internal/setup/assets/claude/prime.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-PROMPT_DIR="${HOME}/.mnemon/prompt"
+PROMPT_DIR="${MNEMON_DATA_DIR:-$HOME/.mnemon}/prompt"
+# Fall back to legacy location if the resolved path has no guide yet but the
+# legacy ~/.mnemon/prompt/ does — preserves existing installs that pre-date
+# MNEMON_DATA_DIR-aware setup.
+if [ ! -f "${PROMPT_DIR}/guide.md" ] && [ -f "${HOME}/.mnemon/prompt/guide.md" ]; then
+  PROMPT_DIR="${HOME}/.mnemon/prompt"
+fi
 
 if ! command -v mnemon >/dev/null 2>&1; then
   echo "[mnemon] Warning: mnemon not found in PATH."

--- a/internal/setup/assets/codex/prime.sh
+++ b/internal/setup/assets/codex/prime.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-PROMPT_DIR="${HOME}/.mnemon/prompt"
+PROMPT_DIR="${MNEMON_DATA_DIR:-$HOME/.mnemon}/prompt"
+# Fall back to legacy location if the resolved path has no guide yet but the
+# legacy ~/.mnemon/prompt/ does — preserves existing installs that pre-date
+# MNEMON_DATA_DIR-aware setup.
+if [ ! -f "${PROMPT_DIR}/guide.md" ] && [ -f "${HOME}/.mnemon/prompt/guide.md" ]; then
+  PROMPT_DIR="${HOME}/.mnemon/prompt"
+fi
 
 if ! command -v mnemon >/dev/null 2>&1; then
   echo "[mnemon] Warning: mnemon not found in PATH."

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -16,28 +16,41 @@ type HookSelection struct {
 	Compact bool // PreCompact — save insights before context compaction
 }
 
-// WritePromptFiles writes guide.md and skill.md to ~/.mnemon/prompt/.
-func WritePromptFiles() (string, error) {
+// promptDir returns the directory where mnemon prompt files (guide.md,
+// skill.md) are written and read. Resolution follows the same convention as
+// the --data-dir flag: MNEMON_DATA_DIR env var if set, else ~/.mnemon.
+func promptDir() (string, error) {
+	if env := os.Getenv("MNEMON_DATA_DIR"); env != "" {
+		return filepath.Join(env, "prompt"), nil
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	promptDir := filepath.Join(home, ".mnemon", "prompt")
-	if err := os.MkdirAll(promptDir, 0755); err != nil {
+	return filepath.Join(home, ".mnemon", "prompt"), nil
+}
+
+// WritePromptFiles writes guide.md and skill.md under promptDir.
+func WritePromptFiles() (string, error) {
+	dir, err := promptDir()
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", err
 	}
 
-	guidePath := filepath.Join(promptDir, "guide.md")
+	guidePath := filepath.Join(dir, "guide.md")
 	if err := os.WriteFile(guidePath, assets.ClaudeGuide, 0644); err != nil {
 		return "", err
 	}
 
-	skillPath := filepath.Join(promptDir, "skill.md")
+	skillPath := filepath.Join(dir, "skill.md")
 	if err := os.WriteFile(skillPath, assets.ClaudeSkill, 0644); err != nil {
 		return "", err
 	}
 
-	return promptDir, nil
+	return dir, nil
 }
 
 // ClaudeWriteSkill writes the mnemon skill to the config dir.

--- a/internal/setup/claude_test.go
+++ b/internal/setup/claude_test.go
@@ -1,0 +1,62 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPromptDirHonorsMnemonDataDir(t *testing.T) {
+	custom := t.TempDir()
+	t.Setenv("MNEMON_DATA_DIR", custom)
+
+	got, err := promptDir()
+	if err != nil {
+		t.Fatalf("promptDir: %v", err)
+	}
+	want := filepath.Join(custom, "prompt")
+	if got != want {
+		t.Fatalf("promptDir = %q, want %q", got, want)
+	}
+}
+
+func TestPromptDirFallsBackToHomeWhenEnvUnset(t *testing.T) {
+	t.Setenv("MNEMON_DATA_DIR", "")
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	got, err := promptDir()
+	if err != nil {
+		t.Fatalf("promptDir: %v", err)
+	}
+	want := filepath.Join(fakeHome, ".mnemon", "prompt")
+	if got != want {
+		t.Fatalf("promptDir = %q, want %q", got, want)
+	}
+}
+
+func TestWritePromptFilesWritesUnderMnemonDataDir(t *testing.T) {
+	custom := t.TempDir()
+	t.Setenv("MNEMON_DATA_DIR", custom)
+
+	path, err := WritePromptFiles()
+	if err != nil {
+		t.Fatalf("WritePromptFiles: %v", err)
+	}
+
+	wantDir := filepath.Join(custom, "prompt")
+	if path != wantDir {
+		t.Fatalf("returned path = %q, want %q", path, wantDir)
+	}
+
+	for _, name := range []string{"guide.md", "skill.md"} {
+		full := filepath.Join(wantDir, name)
+		info, err := os.Stat(full)
+		if err != nil {
+			t.Fatalf("stat %s: %v", full, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("%s is empty", full)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #42.

Setup writes `guide.md` and `skill.md` under `${MNEMON_DATA_DIR:-~/.mnemon}/prompt`
so containers mounting only the custom data dir keep their prompts across restarts.
Both `prime.sh` templates (claude + codex) read from the same resolved location and
fall back to the legacy `~/.mnemon/prompt/` path for existing installs. Setup output
now reports the actual prompt path in each target's summary block.

User-facing change: `MNEMON_DATA_DIR=/custom mnemon setup --target claude-code …`
now lands prompts at `/custom/prompt/` instead of `~/.mnemon/prompt/`. Pre-existing
installs are unaffected.

Validation: `make unit`, `make vet`, `make test`, `go build -o mnemon .`
