### PR TITLE
fix(setup): align OpenClaw prompt path with MNEMON_DATA_DIR

### DIFF
--- a/internal/setup/assets/openclaw/hooks/mnemon-prime/handler.js
+++ b/internal/setup/assets/openclaw/hooks/mnemon-prime/handler.js
@@ -1,9 +1,18 @@
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { execSync } from "child_process";
 
-const GUIDE_PATH = join(homedir(), ".mnemon", "prompt", "guide.md");
+const LEGACY_GUIDE_PATH = join(homedir(), ".mnemon", "prompt", "guide.md");
+
+function guidePath() {
+  const dataRoot = process.env.MNEMON_DATA_DIR || join(homedir(), ".mnemon");
+  const scopedPath = join(dataRoot, "prompt", "guide.md");
+  if (!existsSync(scopedPath) && existsSync(LEGACY_GUIDE_PATH)) {
+    return LEGACY_GUIDE_PATH;
+  }
+  return scopedPath;
+}
 
 const handler = async (event) => {
   if (event.type !== "agent" || event.action !== "bootstrap") return;
@@ -30,7 +39,7 @@ const handler = async (event) => {
 
   // Inject behavioral guide
   try {
-    const guide = readFileSync(GUIDE_PATH, "utf-8");
+    const guide = readFileSync(guidePath(), "utf-8");
     if (guide) parts.push(guide);
   } catch {
     // guide.md not found — skill-only mode, no guide injection

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -17,8 +17,8 @@ type HookSelection struct {
 }
 
 // promptDir returns the directory where mnemon prompt files (guide.md,
-// skill.md) are written and read. Resolution follows the same convention as
-// the --data-dir flag: MNEMON_DATA_DIR env var if set, else ~/.mnemon.
+// skill.md) are written and read. Resolution follows MNEMON_DATA_DIR if set,
+// else ~/.mnemon.
 func promptDir() (string, error) {
 	if env := os.Getenv("MNEMON_DATA_DIR"); env != "" {
 		return filepath.Join(env, "prompt"), nil

--- a/internal/setup/openclaw_test.go
+++ b/internal/setup/openclaw_test.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/mnemon-dev/mnemon/internal/setup/assets"
 )
 
 func TestOpenClawRegisterPluginWritesSelection(t *testing.T) {
@@ -87,5 +90,19 @@ func TestRemoveOpenClawPluginEntryRemovesEmptyConfig(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("expected empty config file removal, got err=%v", err)
+	}
+}
+
+func TestOpenClawPrimeHookResolvesMnemonDataDir(t *testing.T) {
+	handler := string(assets.OpenClawHookHandler)
+	for _, want := range []string{
+		"process.env.MNEMON_DATA_DIR",
+		"LEGACY_GUIDE_PATH",
+		"existsSync(scopedPath)",
+		"readFileSync(guidePath()",
+	} {
+		if !strings.Contains(handler, want) {
+			t.Fatalf("OpenClaw prime hook missing %q", want)
+		}
 	}
 }


### PR DESCRIPTION
Follow-up to #44.

OpenClaw setup now writes prompt files under `~/.mnemon/prompt`, but the OpenClaw bootstrap handler still read only `~/.mnemon/prompt/guide.md`. This updates the handler to resolve the guide from `MNEMON_DATA_DIR` and preserve the legacy fallback, matching the Claude and Codex prime hooks.

Also narrows the promptDir comment so it does not imply full `--data-dir` runtime support.

Validation:
- `go test ./internal/setup`
- `go test ./...`