### PR TITLE
Switch to float32 for storage

### DIFF
--- a/internal/embed/vector.go
+++ b/internal/embed/vector.go
@@ -25,17 +25,29 @@ func CosineSimilarity(a, b []float64) float64 {
 	return dot / (math.Sqrt(normA) * math.Sqrt(normB))
 }
 
-// SerializeVector encodes a float64 slice as a little-endian binary blob.
+// SerializeVector encodes a vector as a little-endian float32 blob.
 func SerializeVector(v []float64) []byte {
-	buf := make([]byte, len(v)*8)
+	buf := make([]byte, len(v)*4)
 	for i, f := range v {
-		binary.LittleEndian.PutUint64(buf[i*8:], math.Float64bits(f))
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(float32(f)))
 	}
 	return buf
 }
 
-// DeserializeVector decodes a little-endian binary blob into a float64 slice.
+// DeserializeVector decodes a little-endian float32 blob into a float64 slice.
 func DeserializeVector(b []byte) []float64 {
+	if len(b) == 0 || len(b)%4 != 0 {
+		return nil
+	}
+	v := make([]float64, len(b)/4)
+	for i := range v {
+		v[i] = float64(math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:])))
+	}
+	return v
+}
+
+// DeserializeLegacyVector decodes a pre-migration little-endian float64 blob.
+func DeserializeLegacyVector(b []byte) []float64 {
 	if len(b) == 0 || len(b)%8 != 0 {
 		return nil
 	}

--- a/internal/embed/vector_test.go
+++ b/internal/embed/vector_test.go
@@ -1,6 +1,7 @@
 package embed
 
 import (
+	"encoding/binary"
 	"math"
 	"testing"
 )
@@ -70,9 +71,28 @@ func TestCosineSimilarity_ScaledVector(t *testing.T) {
 }
 
 func TestSerializeDeserialize_Roundtrip(t *testing.T) {
-	original := []float64{1.5, -2.7, 0.0, 3.14159, math.MaxFloat64}
+	original := []float64{1.5, -2.7, 0.0, 3.14159, -0.125}
 	blob := SerializeVector(original)
 	restored := DeserializeVector(blob)
+
+	wantLen := len(original) * 4
+	if len(blob) != wantLen {
+		t.Fatalf("blob length: want %d, got %d", wantLen, len(blob))
+	}
+	if len(restored) != len(original) {
+		t.Fatalf("length mismatch: want %d, got %d", len(original), len(restored))
+	}
+	for i := range original {
+		if math.Abs(original[i]-restored[i]) > 1e-6 {
+			t.Errorf("index %d: want %f, got %f", i, original[i], restored[i])
+		}
+	}
+}
+
+func TestDeserializeVector_LegacyFloat64(t *testing.T) {
+	original := []float64{1.5, -2.7, 0.0, 3.14159, math.MaxFloat64}
+	blob := serializeLegacyFloat64(original)
+	restored := DeserializeLegacyVector(blob)
 
 	if len(restored) != len(original) {
 		t.Fatalf("length mismatch: want %d, got %d", len(original), len(restored))
@@ -101,8 +121,22 @@ func TestDeserializeVector_Empty(t *testing.T) {
 }
 
 func TestDeserializeVector_InvalidLength(t *testing.T) {
-	// 7 bytes is not a multiple of 8
+	// 7 bytes is not a multiple of 4
 	if v := DeserializeVector(make([]byte, 7)); v != nil {
 		t.Errorf("invalid blob length: want nil, got %v", v)
 	}
+}
+
+func TestDeserializeLegacyVector_InvalidLength(t *testing.T) {
+	if v := DeserializeLegacyVector(make([]byte, 7)); v != nil {
+		t.Errorf("invalid legacy blob length: want nil, got %v", v)
+	}
+}
+
+func serializeLegacyFloat64(v []float64) []byte {
+	buf := make([]byte, len(v)*8)
+	for i, f := range v {
+		binary.LittleEndian.PutUint64(buf[i*8:], math.Float64bits(f))
+	}
+	return buf
 }

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -3,17 +3,21 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/mnemon-dev/mnemon/internal/embed"
 	_ "modernc.org/sqlite"
 )
 
 // DefaultStoreName is the fallback store when none is specified.
 const DefaultStoreName = "default"
+
+const embeddingFloat32UserVersion = 1
 
 var validStoreNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 
@@ -311,6 +315,9 @@ CREATE INDEX IF NOT EXISTS idx_oplog_created ON oplog(created_at);
 	if err := addColumnIfNotExists(db.conn, `ALTER TABLE insights ADD COLUMN embedding BLOB`); err != nil {
 		return fmt.Errorf("add embedding: %w", err)
 	}
+	if err := db.migrateEmbeddingsToFloat32(); err != nil {
+		return fmt.Errorf("migrate embeddings to float32: %w", err)
+	}
 
 	// Lifecycle migration: add effective_importance column
 	if err := addColumnIfNotExists(db.conn, `ALTER TABLE insights ADD COLUMN effective_importance REAL DEFAULT 0.5`); err != nil {
@@ -349,6 +356,82 @@ func addColumnIfNotExists(conn *sql.DB, stmt string) error {
 		return nil
 	}
 	return err
+}
+
+func (db *DB) migrateEmbeddingsToFloat32() error {
+	var userVersion int
+	if err := db.conn.QueryRow(`PRAGMA user_version`).Scan(&userVersion); err != nil {
+		return err
+	}
+	if userVersion >= embeddingFloat32UserVersion {
+		return nil
+	}
+
+	tx, err := db.conn.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.Query(`SELECT id, embedding FROM insights WHERE embedding IS NOT NULL`)
+	if err != nil {
+		return fmt.Errorf("select embeddings: %w", err)
+	}
+	type migratedEmbedding struct {
+		id   string
+		blob []byte
+	}
+	var migrated []migratedEmbedding
+	for rows.Next() {
+		var id string
+		var blob []byte
+		if err := rows.Scan(&id, &blob); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan embedding: %w", err)
+		}
+		vec := embed.DeserializeLegacyVector(blob)
+		if vec == nil || !looksLikeLegacyVector(vec) {
+			// Not a parseable legacy float64 blob (empty, malformed, or
+			// already in float32 form) — leave it untouched. Aborting the
+			// whole migration over one bad row would permanently block the
+			// database from opening, and re-encoding non-legacy data here
+			// would silently corrupt it.
+			fmt.Fprintf(os.Stderr, "mnemon: skipping float32 migration for insight %s: embedding is not a legacy float64 vector (%d bytes)\n", id, len(blob))
+			continue
+		}
+		migrated = append(migrated, migratedEmbedding{id: id, blob: embed.SerializeVector(vec)})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("scan embeddings: %w", err)
+	}
+	rows.Close()
+
+	for _, item := range migrated {
+		if _, err := tx.Exec(`UPDATE insights SET embedding = ? WHERE id = ?`, item.blob, item.id); err != nil {
+			return fmt.Errorf("update embedding %s: %w", item.id, err)
+		}
+	}
+	if _, err := tx.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, embeddingFloat32UserVersion)); err != nil {
+		return fmt.Errorf("set user_version: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// looksLikeLegacyVector reports whether v's values are plausible for an
+// embedding (finite and of reasonable magnitude). It guards against
+// misreading an already-migrated float32 blob as legacy float64: reinterpreting
+// arbitrary float32 bit patterns as float64 yields NaN, Inf, or extreme
+// magnitudes with overwhelming probability, so a vector that looks "normal"
+// is almost certainly genuine legacy data.
+func looksLikeLegacyVector(v []float64) bool {
+	for _, f := range v {
+		if math.IsNaN(f) || math.IsInf(f, 0) || math.Abs(f) > 1e6 {
+			return false
+		}
+	}
+	return true
 }
 
 // migrateRemoveNarrativeEdges recreates the edges table without the 'narrative' type

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,12 +1,15 @@
 package store
 
 import (
+	"bytes"
+	"encoding/binary"
 	"math"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/mnemon-dev/mnemon/internal/embed"
 	"github.com/mnemon-dev/mnemon/internal/model"
 )
 
@@ -562,7 +565,7 @@ func TestUpdateAndGetEmbedding(t *testing.T) {
 	db := testDB(t)
 	db.InsertInsight(makeInsight("emb-1", "content", 3))
 
-	blob := []byte{1, 2, 3, 4, 5, 6, 7, 8} // 1 float64
+	blob := []byte{1, 2, 3, 4} // 1 float32
 	if err := db.UpdateEmbedding("emb-1", blob); err != nil {
 		t.Fatalf("update embedding: %v", err)
 	}
@@ -571,8 +574,135 @@ func TestUpdateAndGetEmbedding(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get embedding: %v", err)
 	}
+	if len(got) != 4 {
+		t.Errorf("want 4 bytes, got %d", len(got))
+	}
+}
+
+func TestMigrateEmbeddingsToFloat32(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.InsertInsight(makeInsight("emb-mig-1", "legacy embedding", 3)); err != nil {
+		t.Fatalf("insert insight: %v", err)
+	}
+	legacy := serializeLegacyEmbedding([]float64{1.5, -2.25})
+	if err := db.UpdateEmbedding("emb-mig-1", legacy); err != nil {
+		t.Fatalf("update legacy embedding: %v", err)
+	}
+	if _, err := db.conn.Exec(`PRAGMA user_version = 0`); err != nil {
+		t.Fatalf("clear user_version: %v", err)
+	}
+	db.Close()
+
+	db, err = Open(dir)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer db.Close()
+
+	var userVersion int
+	if err := db.conn.QueryRow(`PRAGMA user_version`).Scan(&userVersion); err != nil {
+		t.Fatalf("get user_version: %v", err)
+	}
+	if userVersion != embeddingFloat32UserVersion {
+		t.Fatalf("user_version: want %d, got %d", embeddingFloat32UserVersion, userVersion)
+	}
+
+	got, err := db.GetEmbedding("emb-mig-1")
+	if err != nil {
+		t.Fatalf("get migrated embedding: %v", err)
+	}
 	if len(got) != 8 {
-		t.Errorf("want 8 bytes, got %d", len(got))
+		t.Fatalf("migrated blob length: want 8 bytes, got %d", len(got))
+	}
+	vec := embed.DeserializeVector(got)
+	if len(vec) != 2 {
+		t.Fatalf("migrated vector length: want 2, got %d", len(vec))
+	}
+	if math.Abs(vec[0]-1.5) > 1e-6 || math.Abs(vec[1]-(-2.25)) > 1e-6 {
+		t.Fatalf("migrated vector: got %v", vec)
+	}
+}
+
+func TestMigrateEmbeddingsToFloat32_SkipsUnreadableBlobs(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	// A genuine legacy float64 embedding — should be migrated normally.
+	if err := db.InsertInsight(makeInsight("emb-mig-good", "good", 3)); err != nil {
+		t.Fatalf("insert good insight: %v", err)
+	}
+	good := serializeLegacyEmbedding([]float64{0.5, -0.75})
+	if err := db.UpdateEmbedding("emb-mig-good", good); err != nil {
+		t.Fatalf("update good embedding: %v", err)
+	}
+
+	// A malformed blob whose length isn't a multiple of 8 must not abort the
+	// whole migration (and thus block the database from ever opening again).
+	if err := db.InsertInsight(makeInsight("emb-mig-malformed", "malformed", 3)); err != nil {
+		t.Fatalf("insert malformed insight: %v", err)
+	}
+	malformed := []byte{1, 2, 3, 4, 5}
+	if err := db.UpdateEmbedding("emb-mig-malformed", malformed); err != nil {
+		t.Fatalf("update malformed embedding: %v", err)
+	}
+
+	// A blob whose bytes decode to NaN as float64 simulates already-migrated
+	// float32 (or other non-legacy) data that happens to satisfy len%8==0.
+	// It must be left untouched rather than re-encoded as garbage.
+	if err := db.InsertInsight(makeInsight("emb-mig-implausible", "implausible", 3)); err != nil {
+		t.Fatalf("insert implausible insight: %v", err)
+	}
+	implausible := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+	if err := db.UpdateEmbedding("emb-mig-implausible", implausible); err != nil {
+		t.Fatalf("update implausible embedding: %v", err)
+	}
+
+	if _, err := db.conn.Exec(`PRAGMA user_version = 0`); err != nil {
+		t.Fatalf("clear user_version: %v", err)
+	}
+	db.Close()
+
+	db, err = Open(dir)
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer db.Close()
+
+	var userVersion int
+	if err := db.conn.QueryRow(`PRAGMA user_version`).Scan(&userVersion); err != nil {
+		t.Fatalf("get user_version: %v", err)
+	}
+	if userVersion != embeddingFloat32UserVersion {
+		t.Fatalf("user_version: want %d, got %d", embeddingFloat32UserVersion, userVersion)
+	}
+
+	got, err := db.GetEmbedding("emb-mig-good")
+	if err != nil {
+		t.Fatalf("get migrated embedding: %v", err)
+	}
+	vec := embed.DeserializeVector(got)
+	if len(vec) != 2 || math.Abs(vec[0]-0.5) > 1e-6 || math.Abs(vec[1]-(-0.75)) > 1e-6 {
+		t.Fatalf("migrated vector: got %v", vec)
+	}
+
+	for id, want := range map[string][]byte{
+		"emb-mig-malformed":   malformed,
+		"emb-mig-implausible": implausible,
+	} {
+		gotBlob, err := db.GetEmbedding(id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if !bytes.Equal(gotBlob, want) {
+			t.Fatalf("%s blob: want %v, got %v (should be left untouched)", id, want, gotBlob)
+		}
 	}
 }
 
@@ -767,6 +897,14 @@ func TestMigrateIfNeeded_NoLegacy(t *testing.T) {
 	if err := MigrateIfNeeded(base); err != nil {
 		t.Fatalf("migrate empty: %v", err)
 	}
+}
+
+func serializeLegacyEmbedding(v []float64) []byte {
+	buf := make([]byte, len(v)*8)
+	for i, f := range v {
+		binary.LittleEndian.PutUint64(buf[i*8:], math.Float64bits(f))
+	}
+	return buf
 }
 
 // --- LoadKnownEntities ---


### PR DESCRIPTION
Mnemon currently persists embedding vectors as raw float64 blobs. That is more precision than the data needs and doubles the storage cost. Ollama/model embeddings are effectively float32 tensor values; they are decoded into Go float64 mainly because JSON numbers land there naturally. Persisting them as float64 does not improve cosine ranking, diff matching, or semantic edge creation in practice. This change stores embeddings as raw little-endian float32 blobs instead. For a 768-dimensional embedding, storage drops from 6144 bytes to 3072 bytes per insight. The in-process API can still use []float64, so the search and graph code stays unchanged while the database uses the more appropriate representation. The migration is database-level and one-time. On first open, Mnemon checks SQLite PRAGMA user_version; databases below the float32 embedding version have their existing raw float64 embedding blobs rewritten to raw float32 inside a transaction, then user_version is advanced. New databases and already-migrated databases write float32 directly. There is intentionally no per-blob header. The format is compact, and the database migration marker makes decoding unambiguous: after migration, stored embeddings are float32. This avoids repeated metadata overhead in every embedding blob while keeping existing databases upgradeable.

## What

Brief description of changes.

## Why

Link to issue or explain the motivation.

## Checklist

- [x] Tests pass (`make test` and `go test ./...`)
- [x] New/changed behavior is covered by tests
- [ ] Documentation updated (USAGE.md, DESIGN.md, or README) if applicable
- [ ] User-facing release-note impact described in this PR, if applicable
