### PR TITLE
docs(readme): mention TRAE Work setup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,15 @@ One command deploys the mnemon skill, prompt files, and Cursor lifecycle hooks
 to `.cursor/`. The integration primes new agent sessions with Mnemon guidance
 and memory status, then nudges for durable-memory writeback after responses.
 
-### [Trae](https://www.trae.ai/)
+### [TRAE](https://www.trae.ai/) (TRAE Work)
 
 ```bash
 mnemon setup --target trae --yes
 ```
 
-One command deploys the mnemon skill, prompt files, and Trae native hooks to
-`.trae/`. The integration uses `SessionStart`, `UserPromptSubmit`, and `Stop`
-hooks in `.trae/hooks.json`.
+One command deploys the mnemon skill, prompt files, and TRAE native hooks for
+both TRAE IDE and TRAE Work to `.trae/`. The integration uses `SessionStart`,
+`UserPromptSubmit`, and `Stop` hooks in `.trae/hooks.json`.
 
 ### [OpenClaw](https://github.com/openclaw/openclaw)
 


### PR DESCRIPTION
## Summary
- update the README TRAE section title to include TRAE Work
- clarify that the existing TRAE setup target covers both TRAE IDE and TRAE Work
- align product casing with official TRAE branding

## Validation
- documentation-only change