### PR TITLE
docs: complete supported agent vision diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ memory is useful.
 
 - **Zero user-side operation** — install once; supported runtimes can use hooks, minimal runtimes can use persistent rules
 - **LLM-supervised** — the host LLM decides what to remember, update, and forget; no embedded LLM, no API keys
-- **Multi-framework support** — Claude Code, Codex, Cursor, Qoder, and QoderWork (hooks), OpenClaw (plugins), Pi (extensions), Nanobot (skills), and more
+- **Multi-framework support** — Claude Code, Codex, Cursor, TRAE/TRAE Work, Qoder/QoderWork, and Hermes Agent (hooks), OpenClaw (plugins), Pi (extensions), Nanobot (skills), and more
 - **Markdown-installable harness** — `SKILL.md`, `INSTALL.md`, `GUIDELINE.md`, and four lifecycle reminders
 - **Four-graph architecture** — temporal, entity, causal, and semantic edges, not just vector similarity
 - **Intent-native protocol** — three primitives (`remember`, `link`, `recall`) map to the LLM's cognitive vocabulary, not database syntax; structured JSON output with signal transparency
@@ -254,9 +254,15 @@ All your local agentic AIs — across sessions and frameworks — sharing one po
                 │
   Cursor ───────┤
                 │
+  TRAE ─────────┤
+                │
+  TRAE Work ────┤
+                │
   Qoder ────────┤
                 │
   QoderWork ────┤
+                │
+  Hermes Agent ─┤
                 │
   OpenClaw ─────┤
                 │
@@ -272,12 +278,12 @@ All your local agentic AIs — across sessions and frameworks — sharing one po
 ```
 
 The foundation is in place: a single `~/.mnemon` database that any agent can
-read and write. Claude Code, Codex, Cursor, Qoder, and QoderWork setup automate hook
-installation; OpenClaw can use plugin hooks; Pi integrates via native skills
-and TypeScript lifecycle extensions; Nanobot integrates via skill files;
-NanoClaw integrates via container skills and volume mounts. The same harness can
-be installed in any LLM CLI that supports skills, rules, system prompts, or
-event hooks.
+read and write. Claude Code, Codex, Cursor, TRAE/TRAE Work, Qoder/QoderWork,
+and Hermes Agent setup automate hook installation; OpenClaw can use plugin
+hooks; Pi integrates via native skills and TypeScript lifecycle extensions;
+Nanobot integrates via skill files; NanoClaw integrates via container skills and
+volume mounts. The same harness can be installed in any LLM CLI that supports
+skills, rules, system prompts, or event hooks.
 
 The longer-term direction is a **memory gateway**: protocol decoupled from storage engine. The current SQLite backend is the first adapter; the protocol surface (`remember / link / recall`) can sit on top of PostgreSQL, Neo4j, or any graph database. Agent-side optimization (when to recall, what to remember) and storage-side optimization (indexing, graph algorithms) evolve independently. See [Future Direction](docs/design/08-decisions.md#82-future-direction) for details.
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -196,7 +196,7 @@ Agent 工作，并且只在有用时调用 Mnemon
 
 - **零用户操作** — 安装一次；支持 hook 的 runtime 可用 hook，minimal runtime 可用持久规则
 - **LLM 监督式** — 宿主 LLM 主动决定记什么、更新什么、遗忘什么；无内嵌 LLM，无 API 密钥
-- **多框架支持** — Claude Code、Codex、Cursor、Qoder 和 QoderWork（hooks）、OpenClaw（plugins）、Pi（extensions）、Nanobot（skills）等
+- **多框架支持** — Claude Code、Codex、Cursor、TRAE/TRAE Work、Qoder/QoderWork 和 Hermes Agent（hooks）、OpenClaw（plugins）、Pi（extensions）、Nanobot（skills）等
 - **Markdown 可安装 harness** — `SKILL.md`、`INSTALL.md`、`GUIDELINE.md` 和四个生命周期提醒
 - **四图架构** — 时序、实体、因果、语义四种边，不仅仅是向量相似度
 - **意图原生协议** — 三个原语（`remember`、`link`、`recall`）映射到 LLM 的认知词汇而非数据库语法；结构化 JSON 输出，带信号透明度
@@ -212,9 +212,25 @@ Agent 工作，并且只在有用时调用 Mnemon
 ```
   Claude Code ──┐
                 │
+  Codex ────────┤
+                │
+  Cursor ───────┤
+                │
+  TRAE ─────────┤
+                │
+  TRAE Work ────┤
+                │
+  Qoder ────────┤
+                │
+  QoderWork ────┤
+                │
+  Hermes Agent ─┤
+                │
   OpenClaw ─────┤
                 │
   Pi ───────────┤
+                │
+  Nanobot ──────┤
                 │
   NanoClaw ─────┤
                 ├──▶  ~/.mnemon  ◀── 共享记忆
@@ -223,7 +239,7 @@ Agent 工作，并且只在有用时调用 Mnemon
   Gemini CLI ───┘
 ```
 
-基础已就绪：一个 `~/.mnemon` 数据库，任何 agent 都可以读写。Claude Code setup 可自动安装 hook；OpenClaw 可以使用 plugin hooks；Pi 通过原生 skill 和 TypeScript lifecycle extension 集成；NanoClaw 通过容器技能和卷挂载集成。同一个 harness 可以安装到任何支持 skill、rule、system prompt 或 event hook 的 LLM CLI。
+基础已就绪：一个 `~/.mnemon` 数据库，任何 agent 都可以读写。Claude Code、Codex、Cursor、TRAE/TRAE Work、Qoder/QoderWork 和 Hermes Agent setup 可自动安装 hook；OpenClaw 可以使用 plugin hooks；Pi 通过原生 skill 和 TypeScript lifecycle extension 集成；Nanobot 通过 skill 文件集成；NanoClaw 通过容器技能和卷挂载集成。同一个 harness 可以安装到任何支持 skill、rule、system prompt 或 event hook 的 LLM CLI。
 
 更长远的方向是**记忆网关**：协议层与存储引擎解耦。当前 SQLite 后端是第一个适配器；协议面（`remember / link / recall`）可运行在 PostgreSQL、Neo4j 或任何图数据库之上。Agent 侧优化（何时召回、记什么）与存储侧优化（索引、图算法）独立演进。详见[未来方向](design/08-decisions.md#82-未来方向)。
 


### PR DESCRIPTION
## Summary

- add TRAE/TRAE Work and Hermes Agent to the English README vision diagram
- align the Chinese README diagram with the English one by adding Codex, Cursor, Qoder/QoderWork, Hermes Agent, and Nanobot
- update the surrounding multi-framework support text in both READMEs

## Validation

Not run; documentation-only change.
