### PR TITLE
fix: preserve v0.2 Memory compatibility

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,6 +60,12 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: "https://github.com/mnemon-dev/mnemon"
     description: "Persistent memory and durable agency for LLM agents"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/mnemon"]
+          end
 
 release:
   github:

--- a/cmd/agency/serve.go
+++ b/cmd/agency/serve.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/mnemon-dev/mnemon/internal/daemon"
@@ -37,7 +39,9 @@ func runServe(command *cobra.Command, _ []string) error {
 	}
 	resolved, err := resolveStateDirectory(stateDirectory)
 	if err == nil {
-		err = serveDaemon(command.Context(), resolved)
+		lifetime, stop := signal.NotifyContext(command.Context(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		err = serveDaemon(lifetime, resolved)
 	}
 	if err != nil {
 		return commandFailure{code: 1, err: fmt.Errorf("mnemon agency serve: %w", err)}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,8 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 	}
 	root := productRoot()
 	agencyRequest := false
-	if command, _, findErr := root.Find(args); findErr == nil {
+	command, _, findErr := root.Find(args)
+	if findErr == nil {
 		agencyRequest = belongsToAgency(command)
 		if agencyRequest {
 			root.SilenceErrors = true
@@ -40,7 +41,7 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 	if err == nil {
 		return 0
 	}
-	if !agencyRequest && !belongsToAgency(executed) && executed != nil {
+	if findErr == nil && !agencyRequest && !belongsToAgency(executed) && executed != nil {
 		_, _ = fmt.Fprintln(stderr, executed.UsageString())
 	}
 	if err.Error() != "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,22 +13,25 @@ import (
 
 var version = "dev"
 
-// Execute runs one Mnemon command. Process signal handling and exit remain the
-// root main package's responsibility.
+// Execute runs one Mnemon command. Process exit remains the root main package's
+// responsibility; a long-running command owns any graceful signal handling it
+// requires so ordinary Memory commands retain the operating system defaults.
 func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if ctx == nil || stdin == nil || stdout == nil || stderr == nil {
 		return 1
 	}
 	root := productRoot()
+	agencyRequest := false
 	if command, _, findErr := root.Find(args); findErr == nil {
-		for current := command; current != nil; current = current.Parent() {
-			if current.Name() == "agency" {
-				root.SilenceErrors = true
-				root.SilenceUsage = true
-				break
-			}
+		agencyRequest = belongsToAgency(command)
+		if agencyRequest {
+			root.SilenceErrors = true
 		}
 	}
+	// Cobra renders automatic usage through the command output writer. Keep
+	// successful help and version output on stdout, but render Memory's usage
+	// explicitly to stderr after an execution error, as the established CLI did.
+	root.SilenceUsage = true
 	root.SetArgs(args)
 	root.SetIn(stdin)
 	root.SetOut(stdout)
@@ -37,18 +40,28 @@ func Execute(ctx context.Context, args []string, stdin io.Reader, stdout, stderr
 	if err == nil {
 		return 0
 	}
+	if !agencyRequest && !belongsToAgency(executed) && executed != nil {
+		_, _ = fmt.Fprintln(stderr, executed.UsageString())
+	}
 	if err.Error() != "" {
 		_, _ = fmt.Fprintln(stderr, err)
 	}
 	if code, ok := agency.ExitCode(err); ok {
 		return code
 	}
-	for command := executed; command != nil; command = command.Parent() {
-		if command.Name() == "agency" {
-			return 2
-		}
+	if agencyRequest || belongsToAgency(executed) {
+		return 2
 	}
 	return 1
+}
+
+func belongsToAgency(command *cobra.Command) bool {
+	for current := command; current != nil; current = current.Parent() {
+		if current.Name() == "agency" {
+			return true
+		}
+	}
+	return false
 }
 
 func productRoot() *cobra.Command {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -54,9 +54,22 @@ func TestMemoryKeepsItsExistingCobraErrorOutput(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	exitCode := Execute(context.Background(), []string{"forget"},
 		strings.NewReader(""), &stdout, &stderr)
-	if exitCode != 1 || !strings.Contains(stderr.String(), "Error:") ||
-		!strings.Contains(stdout.String(), "Usage:") {
+	if exitCode != 1 || stdout.Len() != 0 ||
+		!strings.Contains(stderr.String(), "Error:") ||
+		!strings.Contains(stderr.String(), "Usage:") ||
+		!strings.Contains(stderr.String(), "\n\naccepts 1 arg(s), received 0\n") {
 		t.Fatalf("memory usage error: exit=%d stdout=%q stderr=%q",
+			exitCode, stdout.String(), stderr.String())
+	}
+}
+
+func TestMemoryHelpRemainsSuccessfulStdout(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Execute(context.Background(), []string{"forget", "--help"},
+		strings.NewReader(""), &stdout, &stderr)
+	if exitCode != 0 || !strings.Contains(stdout.String(), "mnemon forget [id]") ||
+		stderr.Len() != 0 {
+		t.Fatalf("memory help: exit=%d stdout=%q stderr=%q",
 			exitCode, stdout.String(), stderr.String())
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -73,3 +73,15 @@ func TestMemoryHelpRemainsSuccessfulStdout(t *testing.T) {
 			exitCode, stdout.String(), stderr.String())
 	}
 }
+
+func TestUnknownRootCommandKeepsTheShortCobraDiagnostic(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Execute(context.Background(), []string{"unknown"},
+		strings.NewReader(""), &stdout, &stderr)
+	if exitCode != 1 || stdout.Len() != 0 ||
+		!strings.Contains(stderr.String(), "Run 'mnemon --help' for usage.") ||
+		strings.Contains(stderr.String(), "Usage:\n") {
+		t.Fatalf("unknown command: exit=%d stdout=%q stderr=%q",
+			exitCode, stdout.String(), stderr.String())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,16 +3,12 @@ package main
 import (
 	"context"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/mnemon-dev/mnemon/cmd"
 )
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	exitCode := cmd.Execute(ctx, os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
-	stop()
+	exitCode := cmd.Execute(context.Background(), os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
 	if exitCode != 0 {
 		os.Exit(exitCode)
 	}


### PR DESCRIPTION
## Summary

- restore default SIGINT/SIGTERM behavior for ordinary Memory commands while keeping graceful shutdown scoped to `mnemon agency serve`
- preserve the established Memory stderr usage/error contract and stdout help contract
- prepare the unsigned macOS CLI for Homebrew Cask installation

## Validation

- `make test`
- `bash scripts/e2e_test.sh` (151/151)
- `go test ./test/mnemond/process -count=1`
- blocking Memory import exits with status 143 on SIGTERM