### PR TITLE
fix(artifact): report creation when a Put promotes another writer's marker

### DIFF
--- a/internal/agency/artifact/store.go
+++ b/internal/agency/artifact/store.go
@@ -130,17 +130,27 @@ func (store *Store) Put(ctx context.Context, digest agency.Digest,
 	if err != nil {
 		return PutResult{}, err
 	}
-	_, present, err := store.settlePromotion(ctx, digest, final)
+	// The first settle can install the final link itself: another writer may
+	// have staged a complete marker and not yet promoted it. Dropping created
+	// here reported the writer that published the object as a replay, and when
+	// the staging writer then lost the link race no caller was told it had
+	// created anything.
+	created, present, err := store.settlePromotion(ctx, digest, final)
 	if err != nil {
 		return PutResult{}, err
 	}
 	if present {
-		return store.inspectReplay(ctx, digest, final, content)
+		result, err := store.inspectReplay(ctx, digest, final, content)
+		if err != nil {
+			return PutResult{}, err
+		}
+		result.Replayed = !created
+		return result, nil
 	}
 	if err := store.stageMarker(ctx, digest, content); err != nil {
 		return PutResult{}, err
 	}
-	created, present, err := store.settlePromotion(ctx, digest, final)
+	created, present, err = store.settlePromotion(ctx, digest, final)
 	if err != nil {
 		return PutResult{}, err
 	}

--- a/internal/agency/artifact/store_test.go
+++ b/internal/agency/artifact/store_test.go
@@ -174,6 +174,46 @@ func TestStoreConcurrentPutHasOneFinalEffectAcrossInstances(t *testing.T) {
 	}
 }
 
+// Promoting another writer's complete marker is how the object gets created,
+// so the promoting Put is the creator. Reporting it as a replay loses the
+// only creation signal: the writer that staged the marker lost the link race
+// and replays too, leaving a stored object no caller claims to have written.
+func TestStorePutReportsCreationWhenItPromotesAnotherWritersMarker(t *testing.T) {
+	root := testRoot(t)
+	stager, err := Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	promoter, err := Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := bytes.Repeat([]byte("staged then promoted"), 128)
+	digest := agency.Sum(content)
+
+	// The marker is complete and verified, but never promoted by its writer.
+	if err := stager.stageMarker(context.Background(), digest, content); err != nil {
+		t.Fatalf("stage marker: %v", err)
+	}
+
+	promoted, err := promoter.Put(context.Background(), digest, content)
+	if err != nil {
+		t.Fatalf("Put over a staged marker: %v", err)
+	}
+	if promoted.Replayed {
+		t.Error("Put installed the final link, so it created the object and must not report a replay")
+	}
+
+	replay, err := stager.Put(context.Background(), digest, content)
+	if err != nil {
+		t.Fatalf("second Put: %v", err)
+	}
+	if !replay.Replayed {
+		t.Error("a Put against an existing final object must report a replay")
+	}
+	assertPromotionSettled(t, promoter, digest)
+}
+
 func TestStoreConcurrentProcessesPreserveImmutableFinal(t *testing.T) {
 	const helper = "MNEMON_CAS_PROCESS_HELPER"
 	content := bytes.Repeat([]byte("cross-process immutable bytes"), 4096)


### PR DESCRIPTION
`Put` discards the `created` flag from its **first** `settlePromotion`, and `inspectReplay` hardcodes `Replayed: true`. That first settle is not read-only — when another writer has already staged a complete marker, it installs the final link itself. So the writer that actually published the object reports a replay, and the writer that staged the marker replays too (it lost the link race). A stored object can come back with **no creator at all**.

The post-staging path already handles this (`result.Replayed = !created`); the replay branch just never did.

### Reproduction

`TestStoreConcurrentPutHasOneFinalEffectAcrossInstances` already catches it under scheduling pressure — the in-process per-digest mutex is per-`Store`, and the test deliberately uses two instances over one root, so the cross-instance protocol is exercised:

| | before | after |
|---|---|---|
| `GOMAXPROCS=1`, `-count=400` | **94 failures**, all `created results = 0, want 1` | 400/400 pass |
| 64 writers × 4 instances, `-count=150` | **49 failures** | 150/150 pass |
| `GOMAXPROCS=1,2`, whole package `-count=200` | — | pass |

### Test

`TestStorePutReportsCreationWhenItPromotesAnotherWritersMarker` pins the invariant without timing: stage a complete marker on one instance, `Put` the same bytes on another, and the promoting `Put` must not claim a replay. It fails on `master` with `Put installed the final link, so it created the object and must not report a replay`.

### Separate, still open

CI on #98 failed with `artifact: corruption: promotion did not settle` — `settlePromotion` exhausting its eight attempts. That is a **different** path and this PR does not address it. Mechanism, for whoever picks it up: between `os.Link(marker, final)` and the marker's removal the shared inode has `nlink == 2`, while every verifier calls `readVerifiedFile(..., expectedLinks: 1)`; the resulting `ErrCorruption` is classified retryable, and the loop is a fixed 8 attempts with no backoff, so a slow or contended filesystem can exhaust the budget and report corruption for a benign race. I did not reproduce it locally in ~1500 runs across contention profiles, and widening a fail-closed bound seemed like your call rather than something to slip into a fix for an unrelated defect. Happy to open an issue.