### PR TITLE
fix: resolve latest dsh-mnemon release

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ dsh plugin --profile web add "github:omdsh-dev/dsh-mnemon"
 dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
 ```
 
+New installations from the Mnemon repository resolve the `latest` npm release
+of `dsh-mnemon`, so publishing a new plugin release does not require a matching
+change in this repository. Existing installations remain on their resolved
+version until the plugin is reinstalled or updated.
+
 Then open DSH's Settings → Plugin Config → Mnemon to pick a storage scope, and use the Memory System tab in a session to create or activate memory spaces. Recall reads only from active memory spaces; durable writes go through supervised sub-agents.
 
 ### [NanoClaw](https://github.com/qwibitai/nanoclaw)

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,5 +1,6 @@
-# Mount the full dsh-mnemon package pinned in package.json. Keeping the original
-# package as the mounted row preserves its host and browser plugin identities.
+# Mount the full dsh-mnemon package selected by its npm latest tag in
+# package.json. Keeping the original package as the mounted row preserves its
+# host and browser plugin identities.
 - insert:
     - id: mnemon
       name: dsh-mnemon

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -219,6 +219,10 @@ dsh plugin --profile web add "github:omdsh-dev/dsh-mnemon"
 dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
 ```
 
+从 Mnemon 主仓库执行全新安装时，会解析 npm 上标记为 `latest` 的
+`dsh-mnemon` 版本，因此发布新版插件后无需同步修改本仓库。已有安装仍会保留
+此前解析到的版本，直至重新安装或更新插件。
+
 然后在 DSH 的「设置 → 插件配置 → Mnemon」选择存储范围，并在会话的「记忆系统」Tab 创建或激活记忆体。召回只读取已激活的记忆体，持久写入经由受监督子 Agent 执行。
 
 ### [NanoClaw](https://github.com/qwibitai/nanoclaw)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   },
   "dependencies": {
-    "dsh-mnemon": "0.1.0"
+    "dsh-mnemon": "latest"
   },
   "engines": {
     "node": ">=20"

--- a/test/mnemond/architecture/dsh_bundle_test.go
+++ b/test/mnemond/architecture/dsh_bundle_test.go
@@ -31,8 +31,8 @@ func TestDSHGitHubBundleContract(t *testing.T) {
 	if manifest.Name != "@mnemon-dev/dsh-mnemon" {
 		t.Errorf("package name = %q", manifest.Name)
 	}
-	if manifest.Dependencies["dsh-mnemon"] != "0.1.0" {
-		t.Errorf("dsh-mnemon pin = %q", manifest.Dependencies["dsh-mnemon"])
+	if manifest.Dependencies["dsh-mnemon"] != "latest" {
+		t.Errorf("dsh-mnemon dependency = %q, want latest", manifest.Dependencies["dsh-mnemon"])
 	}
 	if manifest.DSH.Bundle.Patch != "./cordis.patch.yml" {
 		t.Errorf("bundle patch = %q", manifest.DSH.Bundle.Patch)


### PR DESCRIPTION
## What

- Resolve the repository bundle's dsh-mnemon dependency through the npm latest dist-tag.
- Keep the dependency contract covered by the architecture test.
- Document fresh-install and existing-install behavior in English and Chinese.

## Why

New dsh-mnemon releases should not require synchronized version bumps in mnemon. Fresh repository-based installs will resolve the current npm latest release.

## Validation

- [x] Deterministic tests pass (make test)
- [x] New behavior is covered by tests
- [x] Documentation updated
- [x] Isolated npm resolution selected dsh-mnemon 0.2.9
