### PR TITLE
feat(memory): add a minimum-age grace period before auto-prune

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -243,6 +243,7 @@ Nodes are colored by category (decision, fact, insight, preference, context); ed
 | `MNEMON_EMBED_ENDPOINT` | `http://localhost:11434` | Ollama API endpoint |
 | `MNEMON_EMBED_MODEL` | `nomic-embed-text` | Ollama embedding model |
 | `MNEMON_EMBED_DIMENSIONS` | (native) | Embedding dimensions; set to truncate (e.g., `256` for Matryoshka models) |
+| `MNEMON_PRUNE_MIN_AGE` | (none) | Grace period before a new insight may be auto-pruned (Go duration, e.g., `24h`); insights younger than this are never auto-pruned |
 
 ---
 

--- a/docs/zh/USAGE.md
+++ b/docs/zh/USAGE.md
@@ -247,6 +247,7 @@ open graph.html
 | `MNEMON_EMBED_ENDPOINT` | `http://localhost:11434` | Ollama API 端点 |
 | `MNEMON_EMBED_MODEL` | `nomic-embed-text` | Ollama 嵌入模型 |
 | `MNEMON_EMBED_DIMENSIONS` | (原生维度) | 嵌入向量维度；可设置截断值（例如 Matryoshka 模型使用 `256`） |
+| `MNEMON_PRUNE_MIN_AGE` | (无) | 新洞察可被自动清理前的保护期（Go 时长格式，例如 `24h`）；创建时间不足该时长的洞察不会被自动清理 |
 
 ---
 

--- a/internal/memory/store/node.go
+++ b/internal/memory/store/node.go
@@ -23,7 +23,40 @@ const (
 
 	// PruneBatchSize is how many excess insights to prune at once.
 	PruneBatchSize = 10
+
+	// DefaultPruneMinAge is the default grace period AutoPrune gives a newly
+	// created insight. Zero preserves the historical behavior: an insight is
+	// prunable the moment it is written.
+	DefaultPruneMinAge time.Duration = 0
 )
+
+// PruneMinAge returns the minimum age an insight must reach before AutoPrune
+// may soft-delete it. An insight younger than this is spared regardless of
+// importance, access count, or effective_importance.
+//
+// Resolution: MNEMON_PRUNE_MIN_AGE > DefaultPruneMinAge. The value is a Go
+// duration string ("30m", "24h", "168h"); empty or zero means no grace period.
+// An unparseable or negative value is reported on stderr and ignored, so a
+// typo cannot silently widen what auto-prune is allowed to take.
+//
+// Resolved at call time rather than at package init, so a caller or test that
+// sets the variable after start-up sees the value it set.
+func PruneMinAge() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("MNEMON_PRUNE_MIN_AGE"))
+	if raw == "" {
+		return DefaultPruneMinAge
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "warning: invalid MNEMON_PRUNE_MIN_AGE %q: %v (ignored)\n", raw, err)
+		return DefaultPruneMinAge
+	}
+	if d < 0 {
+		fmt.Fprintf(os.Stderr, "warning: negative MNEMON_PRUNE_MIN_AGE %q (ignored)\n", raw)
+		return DefaultPruneMinAge
+	}
+	return d
+}
 
 // InsertInsight inserts a new insight into the database.
 func (db *DB) InsertInsight(i *model.Insight) error {
@@ -443,13 +476,23 @@ func (db *DB) autoPrune(maxInsights int, excludeIDs []string) (int, error) {
 		}
 		excludeClause = fmt.Sprintf("AND id NOT IN (%s)", strings.Join(placeholders, ","))
 	}
+	// Spare insights inside the grace period. The capacity check runs on every
+	// write, so in a store that sits over capacity an insight can otherwise be
+	// created and reaped before anything has had the chance to read it once --
+	// and access_count, the only other protection a low-importance insight has,
+	// cannot rise until something does. Age is what says "not yet".
+	var minAgeClause string
+	if minAge := PruneMinAge(); minAge > 0 {
+		minAgeClause = "AND created_at <= ?"
+		args = append(args, time.Now().UTC().Add(-minAge).Format(time.RFC3339))
+	}
 	args = append(args, excess)
 
 	// Collect candidate IDs first (close cursor before writing to avoid single-conn deadlock)
 	rows, err := ex.Query(
 		fmt.Sprintf(`SELECT id FROM insights
-		 WHERE deleted_at IS NULL AND importance < 4 AND access_count < 3 %s
-		 ORDER BY effective_importance ASC LIMIT ?`, excludeClause), args...)
+		 WHERE deleted_at IS NULL AND importance < 4 AND access_count < 3 %s %s
+		 ORDER BY effective_importance ASC LIMIT ?`, excludeClause, minAgeClause), args...)
 	if err != nil {
 		return 0, fmt.Errorf("query prune candidates: %w", err)
 	}

--- a/internal/memory/store/store_test.go
+++ b/internal/memory/store/store_test.go
@@ -740,6 +740,81 @@ func TestAutoPrune_RespectsExcludeIDs(t *testing.T) {
 	}
 }
 
+// The grace period exists because the capacity check fires on every write: in
+// a store that sits permanently over capacity, an insight can be created and
+// reaped in the same second, before anything has read it once. Below the
+// configured age, importance and access_count must not decide the question.
+func TestAutoPrune_SparesInsightsYoungerThanMinAge(t *testing.T) {
+	t.Setenv("MNEMON_PRUNE_MIN_AGE", "1h")
+	db := testDB(t)
+
+	aged := makeInsight("aged-1", "written yesterday", 1)
+	aged.CreatedAt = time.Now().UTC().Add(-24 * time.Hour)
+	aged.UpdatedAt = aged.CreatedAt
+	if err := db.InsertInsight(aged); err != nil {
+		t.Fatalf("insert aged: %v", err)
+	}
+	if err := db.InsertInsight(makeInsight("fresh-1", "written just now", 1)); err != nil {
+		t.Fatalf("insert fresh: %v", err)
+	}
+
+	// Max=0 asks auto-prune to take everything it is allowed to take.
+	pruned, err := db.AutoPrune(0, nil)
+	if err != nil {
+		t.Fatalf("auto prune: %v", err)
+	}
+	if pruned != 1 {
+		t.Fatalf("want 1 pruned (only the aged insight), got %d", pruned)
+	}
+	if _, err := db.GetInsightByID("fresh-1"); err != nil {
+		t.Errorf("insight younger than the grace period must survive: %v", err)
+	}
+	if _, err := db.GetInsightByID("aged-1"); err == nil {
+		t.Error("insight older than the grace period should have been pruned")
+	}
+}
+
+// Unset must mean exactly what it meant before the grace period existed.
+func TestAutoPrune_MinAgeUnsetLeavesFreshInsightsPrunable(t *testing.T) {
+	t.Setenv("MNEMON_PRUNE_MIN_AGE", "")
+	db := testDB(t)
+	if err := db.InsertInsight(makeInsight("nograce-1", "written just now", 1)); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	pruned, err := db.AutoPrune(0, nil)
+	if err != nil {
+		t.Fatalf("auto prune: %v", err)
+	}
+	if pruned != 1 {
+		t.Errorf("want 1 pruned with no grace period configured, got %d", pruned)
+	}
+}
+
+func TestPruneMinAge(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset", "", DefaultPruneMinAge},
+		{"duration", "36h", 36 * time.Hour},
+		{"padded", "  30m  ", 30 * time.Minute},
+		{"zero", "0s", 0},
+		// A typo must not silently widen what auto-prune may take.
+		{"unparseable", "24 hours", DefaultPruneMinAge},
+		{"negative", "-1h", DefaultPruneMinAge},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MNEMON_PRUNE_MIN_AGE", tt.env)
+			if got := PruneMinAge(); got != tt.want {
+				t.Errorf("PruneMinAge() with %q = %v, want %v", tt.env, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAutoPrune_NothingToPrune(t *testing.T) {
 	db := testDB(t)
 	db.InsertInsight(makeInsight("ok-1", "content", 3))


### PR DESCRIPTION
## What

Adds `MNEMON_PRUNE_MIN_AGE`, a grace period below which `AutoPrune` will not take an
insight. An insight younger than the configured duration is spared regardless of
importance, access count, or `effective_importance`.

Unset (the default) is an exact no-op: auto-prune behaves as it does today.

## Why

`AutoPrune`'s capacity check runs on every `remember` and every `import`. In a store
that sits over capacity, that means a prune pass fires on every single write — so a
newly created insight can be soft-deleted in the same second it was created, before
anything has read it once.

That is the hole this closes. A low-importance insight has exactly two protections:
`importance >= 4` and `access_count >= 3`. Neither can help a fresh write. Importance
is fixed at write time, and `access_count` cannot rise until something reads the
insight — which is precisely what has not had the chance to happen yet. Age is the only
signal that distinguishes "this was judged and found weak" from "nothing has looked at
it yet."

On my own store this is not hypothetical: it runs permanently over the 1000 cap, so
every write triggers a prune pass, and I have measured writes reaped under a second
after insert. `v0.2.1`'s per-prune oplog row (#96) made that visible; this makes it
avoidable.

This is request 2 of #83.

## How

One extra predicate on the candidate query in `autoPrune`:

    AND created_at <= ?

with the cutoff formatted the same way `GetRecentInsightsInWindow` already formats its
window bound. Resolution happens at call time (`store.PruneMinAge()`), so callers and
tests that set the variable after start-up see the value they set. An unparseable or
negative value is reported on stderr and ignored rather than applied, so a typo cannot
silently widen what auto-prune is allowed to take.

Scoped deliberately to `AutoPrune`. `mnemon gc`'s suggest mode still lists young
insights as retention candidates — that path is advisory and drives an explicit
operator `forget`, which should stay able to name anything. Happy to extend it there
too if you would rather the two agreed.

One interaction worth naming: in a store already over capacity, a grace window
longer than the age of every prunable insight starves the candidate set — auto-prune
finds nothing on any pass and the store grows past the cap until the oldest
candidates age out of the window. That is the intended reading of an opt-in grace
period (the operator has said "never take anything this young"), not a bug, but it
means a large value trades the cap's firmness for the grace guarantee. The sibling
PR #109 making the insight ceiling configurable (#83 request 3) is the right lever for
anyone who finds themselves there deliberately.

## Checklist

- [x] Deterministic tests pass (`make test`)
- [ ] Relevant E2E/process/Docker boundaries pass (`make test-integration`) — not
      affected; no CLI surface, Agency, process, or Docker boundary changes
- [x] New/changed behavior is covered by tests — a spared young insight, the
      unset-default path, and env resolution including the typo and negative cases
- [x] Documentation updated — `MNEMON_PRUNE_MIN_AGE` added to the Configuration
      tables in `docs/USAGE.md` and `docs/zh/USAGE.md`
- [x] Release-note impact: new optional environment variable; no default behavior
      change

## Notes

The default is off rather than some sensible non-zero value, to keep this a pure
opt-in with no behavior change for existing stores. If you would rather ship a default
grace period (24h would cover the same-second reaping case), say so and I will change
the constant.
---

Sibling PR: #109 (#83 request 3). Semantically independent; both touch the same Configuration table rows and lifecycle const block, so whichever merges second carries a trivial keep-both rebase — the conflicts are expected.
