### PR TITLE
docs: restore the Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,11 +449,11 @@ See [Development and Deployment](docs/DEPLOYMENT.md) for Docker, Compose, Ollama
 
 ## Star History
 
-<a href="https://star-history.dera.page/#mnemon-dev/mnemon&type=date">
+<a href="https://star-history.dera.page/#mnemon-dev/mnemon">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -447,6 +447,16 @@ See [Development and Deployment](docs/DEPLOYMENT.md) for Docker, Compose, Ollama
 - [Memory Import Guide](docs/IMPORT.md) — schema and LLM prompt for importing historical chats
 - [Architecture Diagrams](docs/diagrams/) — system architecture, pipelines, lifecycle management
 
+## Star History
+
+<a href="https://star-history.dera.page/#mnemon-dev/mnemon&type=date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=mnemon-dev/mnemon&type=date&legend=top-left" />
+ </picture>
+</a>
+
 ## References
 
 Mnemon combines the paradigm of one paper with the methodology of another, grounded in the structural insight that graph memory is isomorphic to LLM attention. See [Theoretical Foundations](docs/DESIGN.md#25-theoretical-foundations) for details.


### PR DESCRIPTION
The Star History chart was removed in 67afa8c because its data source broke under GitHub stargazer API restrictions. This restores the chart in its original README location using a working replacement domain. The wrap link and the chart image now point to star-history.dera.page and use the /svg endpoint, so the chart renders again without relying on the old sealed-token service.