### PR TITLE
docs: update dsh-mnemon repository owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ hooks.
 
 ### [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
 
-DeepSeek Harness (DSH) integrates through the [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) plugin, which layers DSH's runtime memory, managed project documents, and Mnemon's long-term memory spaces into one supervised three-tier memory system.
+DeepSeek Harness (DSH) integrates through the [dsh-mnemon](https://github.com/Grivn/dsh-mnemon) plugin, which layers DSH's runtime memory, managed project documents, and Mnemon's long-term memory spaces into one supervised three-tier memory system.
 
 With `mnemon` installed on the host (see [Install](#install)), add the plugin and restart your DSH Web profile:
 
@@ -238,7 +238,7 @@ development checkouts use an absolute path:
 
 ```bash
 dsh plugin --profile web add github:mnemon-dev/mnemon
-dsh plugin --profile web add "github:omdsh-dev/dsh-mnemon"
+dsh plugin --profile web add "github:Grivn/dsh-mnemon"
 dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
 ```
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -201,7 +201,7 @@ mnemon setup --target hermes --yes
 
 ### [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)
 
-DeepSeek Harness（DSH）通过 [dsh-mnemon](https://github.com/omdsh-dev/dsh-mnemon) 插件集成：该插件把 DSH 的运行时热记忆、受管项目档案与 Mnemon 长期记忆体组织成一套受监督的三层记忆系统。
+DeepSeek Harness（DSH）通过 [dsh-mnemon](https://github.com/Grivn/dsh-mnemon) 插件集成：该插件把 DSH 的运行时热记忆、受管项目档案与 Mnemon 长期记忆体组织成一套受监督的三层记忆系统。
 
 宿主机安装好 `mnemon`（见[安装](#安装)）后，安装插件并重启 DSH Web profile：
 
@@ -215,7 +215,7 @@ Mnemon 主仓库也可以直接作为 GitHub 安装源。未发布到 npm 的插
 
 ```bash
 dsh plugin --profile web add github:mnemon-dev/mnemon
-dsh plugin --profile web add "github:omdsh-dev/dsh-mnemon"
+dsh plugin --profile web add "github:Grivn/dsh-mnemon"
 dsh plugin --profile web add "link:/absolute/path/to/dsh-mnemon"
 ```
 


### PR DESCRIPTION
Update the English and Chinese integration links after dsh-mnemon moved from omdsh-dev to Grivn.

This also updates the explicit GitHub installation fallback. The primary package installation path remains unchanged.

Validation:
- make test
- new repository URL returns HTTP 200
- no remaining exact old-owner reference in the two integration READMEs