### PR TITLE
test(embed): cover OpenAI dimension override

### DIFF
--- a/internal/memory/embed/openai_test.go
+++ b/internal/memory/embed/openai_test.go
@@ -88,7 +88,8 @@ func TestOpenAIEndpointWithTrailingSlash(t *testing.T) {
 }
 
 func TestOpenAIEmbed(t *testing.T) {
-	t.Setenv("MNEMON_EMBED_MODEL", "bge-m3-mlx-8bit")
+	t.Setenv("MNEMON_EMBED_MODEL", "BAAI/bge-m3")
+	t.Setenv("MNEMON_EMBED_DIMENSIONS", "1024")
 	t.Setenv("MNEMON_EMBED_API_KEY", "sk-test")
 	var gotAuth string
 	var gotBody map[string]any
@@ -120,8 +121,11 @@ func TestOpenAIEmbed(t *testing.T) {
 	if gotAuth != "Bearer sk-test" {
 		t.Errorf("expected Bearer sk-test, got %q", gotAuth)
 	}
-	if gotBody["model"] != "bge-m3-mlx-8bit" {
+	if gotBody["model"] != "BAAI/bge-m3" {
 		t.Errorf("expected model in body, got %v", gotBody["model"])
+	}
+	if gotBody["dimensions"] != float64(1024) {
+		t.Errorf("expected dimensions in body, got %v", gotBody["dimensions"])
 	}
 	if input, _ := gotBody["input"].(string); input != "跨会话记忆测试" {
 		t.Errorf("expected input text, got %v", gotBody["input"])


### PR DESCRIPTION
## Summary

- cover an OpenAI-compatible embedding model that requires an explicit dimension override
- assert that `BAAI/bge-m3` and `dimensions: 1024` are sent to `/v1/embeddings`
- preserve the existing response parsing and authorization coverage

The production implementation already landed in #115. This PR adds regression coverage for the concrete SiliconFlow-style configuration reported in #117.

## Verification

- `go test ./internal/memory/embed -count=1`
- `make test`

Related to #117.
