### PR TITLE
fix(memory): enforce readonly mode across writes

### DIFF
--- a/cmd/memory/embed.go
+++ b/cmd/memory/embed.go
@@ -29,6 +29,11 @@ Modes:
 			return fmt.Errorf("open database: %w", err)
 		}
 		defer db.Close()
+		if !embedStatus {
+			if err := requireWritableDB(db, "embed"); err != nil {
+				return err
+			}
+		}
 
 		ec := embed.NewClientWithModel(resolveEmbedModel())
 		enc := json.NewEncoder(os.Stdout)

--- a/cmd/memory/forget.go
+++ b/cmd/memory/forget.go
@@ -16,7 +16,7 @@ var forgetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id := args[0]
 
-		db, err := openDB()
+		db, err := openWritableDB("forget")
 		if err != nil {
 			return fmt.Errorf("open database: %w", err)
 		}

--- a/cmd/memory/gc.go
+++ b/cmd/memory/gc.go
@@ -44,6 +44,9 @@ Keep mode:
 
 		// Keep mode: boost retention for a specific insight
 		if gcKeepID != "" {
+			if err := requireWritableDB(db, "gc --keep"); err != nil {
+				return err
+			}
 			ins, err := db.GetInsightByID(gcKeepID)
 			if err != nil || ins == nil {
 				return fmt.Errorf("insight %s not found", gcKeepID)

--- a/cmd/memory/import.go
+++ b/cmd/memory/import.go
@@ -48,7 +48,7 @@ exports are documented in docs/IMPORT.md.`,
 			return nil
 		}
 
-		db, err := openDB()
+		db, err := openWritableDB("import")
 		if err != nil {
 			return fmt.Errorf("open database: %w", err)
 		}

--- a/cmd/memory/link.go
+++ b/cmd/memory/link.go
@@ -36,7 +36,7 @@ var linkCmd = &cobra.Command{
 			return fmt.Errorf("weight must be between 0.0 and 1.0, got %.2f", linkWeight)
 		}
 
-		db, err := openDB()
+		db, err := openWritableDB("link")
 		if err != nil {
 			return fmt.Errorf("open database: %w", err)
 		}

--- a/cmd/memory/remember.go
+++ b/cmd/memory/remember.go
@@ -100,7 +100,7 @@ var rememberCmd = &cobra.Command{
 			UpdatedAt:  now,
 		}
 
-		db, err := openDB()
+		db, err := openWritableDB("remember")
 		if err != nil {
 			return fmt.Errorf("open database: %w", err)
 		}

--- a/cmd/memory/root.go
+++ b/cmd/memory/root.go
@@ -39,7 +39,7 @@ func init() {
 	}
 	rootCmd.PersistentFlags().StringVar(&dataDir, "data-dir", defaultDataDir, "base data directory (env: MNEMON_DATA_DIR)")
 	rootCmd.PersistentFlags().StringVar(&storeName, "store", "", "named memory store (overrides MNEMON_STORE and active file)")
-	rootCmd.PersistentFlags().BoolVar(&readOnly, "readonly", false, "open database in read-only mode (no WAL files, safe for read-only mounts)")
+	rootCmd.PersistentFlags().BoolVar(&readOnly, "readonly", false, "open an immutable database snapshot (reject writes; create no WAL files)")
 	rootCmd.PersistentFlags().StringVar(&embedModel, "embed-model", "",
 		fmt.Sprintf("embedding model (env: MNEMON_EMBED_MODEL; default: %s)", embed.DefaultModel))
 }
@@ -97,4 +97,38 @@ func openDB() (*store.DB, error) {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
 	return store.Open(dir)
+}
+
+// openWritableDB opens the selected store and rejects mutating command paths
+// when --readonly is active. The store layer still enforces SQLite mode=ro as
+// a defense in depth; this guard gives callers a stable, actionable CLI error
+// before embeddings or any other command work begins.
+func openWritableDB(action string) (*store.DB, error) {
+	db, err := openDB()
+	if err != nil {
+		return nil, err
+	}
+	if err := requireWritableDB(db, action); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+func requireWritableDB(db *store.DB, action string) error {
+	if db.IsReadOnly() {
+		return readOnlyWriteError(action)
+	}
+	return nil
+}
+
+func requireWritableMode(action string) error {
+	if readOnly {
+		return readOnlyWriteError(action)
+	}
+	return nil
+}
+
+func readOnlyWriteError(action string) error {
+	return fmt.Errorf("%s is unavailable with --readonly: database writes are disabled", action)
 }

--- a/cmd/memory/root_test.go
+++ b/cmd/memory/root_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/mnemon-dev/mnemon/internal/memory/embed"
+	"github.com/mnemon-dev/mnemon/internal/memory/store"
+	"github.com/spf13/cobra"
 )
 
 func TestNewReturnsComposableMemoryRoot(t *testing.T) {
@@ -69,6 +71,79 @@ func TestOpenDBRejectsInvalidStoreNameFromFlag(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "invalid store name") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpenWritableDBRejectsReadOnlyBeforeCommandWork(t *testing.T) {
+	oldDataDir, oldStoreName, oldReadOnly := dataDir, storeName, readOnly
+	t.Cleanup(func() {
+		dataDir, storeName, readOnly = oldDataDir, oldStoreName, oldReadOnly
+	})
+	dataDir = t.TempDir()
+	storeName = ""
+	readOnly = false
+
+	db, err := openDB()
+	if err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+
+	readOnly = true
+	db, err = openWritableDB("remember")
+	if db != nil {
+		db.Close()
+		t.Fatal("read-only writable open returned a database handle")
+	}
+	if err == nil || !strings.Contains(err.Error(), "remember is unavailable with --readonly") {
+		t.Fatalf("unexpected read-only error: %v", err)
+	}
+
+	ro, err := openDB()
+	if err != nil {
+		t.Fatalf("ordinary read-only open must remain available: %v", err)
+	}
+	defer ro.Close()
+	if !ro.IsReadOnly() {
+		t.Fatal("ordinary read-only open returned a writable handle")
+	}
+
+	if got := store.ReadActive(dataDir); got != store.DefaultStoreName {
+		t.Fatalf("active store = %q, want %q", got, store.DefaultStoreName)
+	}
+}
+
+func TestStoreMutationsRejectReadOnlyMode(t *testing.T) {
+	oldDataDir, oldStoreName, oldReadOnly := dataDir, storeName, readOnly
+	t.Cleanup(func() {
+		dataDir, storeName, readOnly = oldDataDir, oldStoreName, oldReadOnly
+	})
+	dataDir = t.TempDir()
+	storeName = ""
+	readOnly = true
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{name: "store create", cmd: storeCreateCmd},
+		{name: "store set", cmd: storeSetCmd},
+		{name: "store remove", cmd: storeRemoveCmd},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd.RunE(nil, []string{"example"})
+			if err == nil || !strings.Contains(err.Error(), tt.name+" is unavailable with --readonly") {
+				t.Fatalf("unexpected read-only error: %v", err)
+			}
+		})
+	}
+
+	if store.StoreExists(dataDir, "example") {
+		t.Fatal("read-only store commands created a store")
 	}
 }
 

--- a/cmd/memory/store.go
+++ b/cmd/memory/store.go
@@ -47,6 +47,9 @@ var storeCreateCmd = &cobra.Command{
 	Short: "Create a new memory store",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireWritableMode("store create"); err != nil {
+			return err
+		}
 		name := args[0]
 		if !store.ValidStoreName(name) {
 			return fmt.Errorf("invalid store name %q: must match [a-zA-Z0-9][a-zA-Z0-9_-]*", name)
@@ -72,6 +75,9 @@ var storeSetCmd = &cobra.Command{
 	Short: "Set the default active store",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireWritableMode("store set"); err != nil {
+			return err
+		}
 		name := args[0]
 		if !store.ValidStoreName(name) {
 			return fmt.Errorf("invalid store name %q: must match [a-zA-Z0-9][a-zA-Z0-9_-]*", name)
@@ -94,6 +100,9 @@ var storeRemoveCmd = &cobra.Command{
 	Short: "Remove a memory store and all its data",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireWritableMode("store remove"); err != nil {
+			return err
+		}
 		name := args[0]
 		if !store.ValidStoreName(name) {
 			return fmt.Errorf("invalid store name %q: must match [a-zA-Z0-9][a-zA-Z0-9_-]*", name)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -13,7 +13,13 @@ These root flags configure Memory commands:
 | `--store <name>` | (auto) | Named memory store (overrides `MNEMON_STORE` and active file) |
 | `--data-dir <path>` | `~/.mnemon` | Base data directory |
 | `--embed-model <name>` | `nomic-embed-text` | Embedding model (overrides `MNEMON_EMBED_MODEL`) |
-| `--readonly` | `false` | Open the Memory database read-only, without creating WAL files |
+| `--readonly` | `false` | Open an immutable Memory database snapshot; reject write commands and create no WAL files |
+
+`--readonly` is intended for a static database snapshot on a read-only mount.
+It rejects commands that mutate Memory data and suppresses incidental recall
+counters/oplog writes. Do not use it to follow a database another process is
+actively changing; immutable snapshots deliberately ignore concurrent WAL
+updates.
 | `--version` | | Print version and exit |
 
 ---

--- a/docs/zh/USAGE.md
+++ b/docs/zh/USAGE.md
@@ -13,7 +13,11 @@
 | `--store <name>` | (自动) | 命名记忆体（覆盖 `MNEMON_STORE` 和 active 文件） |
 | `--data-dir <path>` | `~/.mnemon` | 基础数据目录 |
 | `--embed-model <name>` | `nomic-embed-text` | 嵌入模型（覆盖 `MNEMON_EMBED_MODEL`） |
-| `--readonly` | `false` | 以只读模式打开 Memory 数据库，不创建 WAL 文件 |
+| `--readonly` | `false` | 打开不可变的 Memory 数据库快照；拒绝写命令且不创建 WAL 文件 |
+
+`--readonly` 适用于只读挂载上的静态数据库快照。它会拒绝修改 Memory
+数据的命令，并禁用 recall 计数器和 oplog 等附带写入。请勿用它跟随由另一个
+进程持续修改的数据库；不可变快照会有意忽略并发 WAL 更新。
 | `--version` | | 打印版本并退出 |
 
 ---

--- a/internal/memory/store/db.go
+++ b/internal/memory/store/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -199,16 +200,27 @@ func renameIfExists(oldPath, newPath string) error {
 	return os.Rename(oldPath, newPath)
 }
 
-// OpenReadOnly opens the SQLite database in read-only mode.
-// Safe for read-only filesystem mounts: uses journal_mode=OFF to avoid
-// writing WAL/SHM sidecar files.
+// OpenReadOnly opens an immutable SQLite snapshot in read-only mode.
+// Immutable mode avoids WAL/SHM sidecar files, making the handle safe for a
+// database copied onto a read-only filesystem. Callers must not use this mode
+// to observe a database that another process is actively changing.
 func OpenReadOnly(dataDir string) (*DB, error) {
 	dbPath := filepath.Join(dataDir, "mnemon.db")
 	if _, err := os.Stat(dbPath); err != nil {
 		return nil, fmt.Errorf("database not found: %s", dbPath)
 	}
 
-	conn, err := sql.Open("sqlite", dbPath+"?mode=ro&_pragma=journal_mode(OFF)&_pragma=foreign_keys(1)")
+	// mode=ro is a SQLite URI parameter, not a generic filename query
+	// parameter. Without the file: URI scheme modernc/sqlite treats this as a
+	// normal read-write open and silently ignores the intended protection.
+	dsn := &url.URL{Scheme: "file", Path: filepath.ToSlash(dbPath)}
+	query := dsn.Query()
+	query.Set("mode", "ro")
+	query.Set("immutable", "1")
+	query.Add("_pragma", "foreign_keys(1)")
+	dsn.RawQuery = query.Encode()
+
+	conn, err := sql.Open("sqlite", dsn.String())
 	if err != nil {
 		return nil, fmt.Errorf("open readonly database: %w", err)
 	}

--- a/internal/memory/store/store_test.go
+++ b/internal/memory/store/store_test.go
@@ -69,6 +69,102 @@ func TestInsertAndGetInsight(t *testing.T) {
 	}
 }
 
+func TestOpenReadOnlyRejectsWrites(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "store with spaces")
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("open writable DB: %v", err)
+	}
+	if err := db.InsertInsight(makeInsight("seed", "existing", 3)); err != nil {
+		t.Fatalf("insert seed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close writable DB: %v", err)
+	}
+
+	ro, err := OpenReadOnly(dir)
+	if err != nil {
+		t.Fatalf("open read-only DB: %v", err)
+	}
+	if !ro.IsReadOnly() {
+		t.Fatal("read-only handle must report IsReadOnly")
+	}
+	stats, err := ro.GetStats()
+	if err != nil {
+		t.Fatalf("query through read-only handle: %v", err)
+	}
+	if stats.Total != 1 {
+		t.Fatalf("read-only total insights = %d, want 1", stats.Total)
+	}
+	if err := ro.InsertInsight(makeInsight("forbidden", "must not persist", 3)); err == nil {
+		t.Fatal("read-only handle accepted an insert")
+	}
+	if err := ro.Close(); err != nil {
+		t.Fatalf("close read-only DB: %v", err)
+	}
+
+	reopened, err := Open(dir)
+	if err != nil {
+		t.Fatalf("reopen writable DB: %v", err)
+	}
+	defer reopened.Close()
+	stats, err = reopened.GetStats()
+	if err != nil {
+		t.Fatalf("stats after rejected write: %v", err)
+	}
+	if stats.Total != 1 {
+		t.Fatalf("total insights after rejected write = %d, want 1", stats.Total)
+	}
+}
+
+func TestOpenReadOnlyDoesNotCreateSidecars(t *testing.T) {
+	sourceDir := t.TempDir()
+	db, err := Open(sourceDir)
+	if err != nil {
+		t.Fatalf("open source DB: %v", err)
+	}
+	if err := db.InsertInsight(makeInsight("seed", "snapshot content", 3)); err != nil {
+		t.Fatalf("insert source insight: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close source DB: %v", err)
+	}
+
+	snapshotDir := filepath.Join(t.TempDir(), "read only snapshot")
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
+		t.Fatalf("create snapshot dir: %v", err)
+	}
+	database, err := os.ReadFile(filepath.Join(sourceDir, "mnemon.db"))
+	if err != nil {
+		t.Fatalf("read source DB: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(snapshotDir, "mnemon.db"), database, 0o444); err != nil {
+		t.Fatalf("write snapshot DB: %v", err)
+	}
+
+	ro, err := OpenReadOnly(snapshotDir)
+	if err != nil {
+		t.Fatalf("open snapshot read-only: %v", err)
+	}
+	stats, err := ro.GetStats()
+	if err != nil {
+		t.Fatalf("query snapshot: %v", err)
+	}
+	if stats.Total != 1 {
+		t.Fatalf("snapshot total insights = %d, want 1", stats.Total)
+	}
+	if err := ro.Close(); err != nil {
+		t.Fatalf("close snapshot: %v", err)
+	}
+
+	for _, suffix := range []string{"-wal", "-shm", "-journal"} {
+		path := filepath.Join(snapshotDir, "mnemon.db"+suffix)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("read-only snapshot created sidecar %s (stat error %v)", path, err)
+		}
+	}
+}
+
 func TestGetInsightByID_NotFound(t *testing.T) {
 	db := testDB(t)
 	_, err := db.GetInsightByID("nonexistent")


### PR DESCRIPTION
## Summary

- make `--readonly` reject every CLI path that can mutate memory or store selection
- open SQLite through a correctly encoded `mode=ro&immutable=1` file URI
- enforce the boundary in the store layer as well as the CLI layer
- document the immutable snapshot semantics in English and Chinese

The write gates cover `remember`, `forget`, `link`, non-dry-run `import`, mutating `embed` modes, `gc --keep`, and store create/set/remove. Read-only paths do not create WAL/SHM sidecars, including when the database path contains spaces.

## Verification

- reproduced the bug before the change: `--readonly remember` exited 0 and increased the row count
- after the change, the same command exits non-zero and the row count is unchanged
- focused CLI/store tests cover write rejection, readable snapshots, path encoding, and sidecar absence
- `git diff --check`
- `make test`

Closes #102.
