### PR TITLE
fix(package): align Apache license metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,3 +516,7 @@ Mnemon combines the paradigm of one paper with the methodology of another, groun
 Copyright 2026 Grivn and Mnemon contributors.
 
 [Apache-2.0](LICENSE)
+
+The bracketed copyright example near the end of `LICENSE` is part of Apache
+2.0's standard application appendix; this section carries the project's actual
+copyright notice.

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -453,3 +453,6 @@ Mnemon 取用了一篇论文的范式和另一篇论文的方法论，并基于�
 Copyright 2026 Grivn and Mnemon contributors.
 
 [Apache-2.0](../../LICENSE)
+
+`LICENSE` 末尾带方括号的版权示例属于 Apache 2.0 标准许可证的应用附录；
+本节所列内容才是本项目的实际版权声明。

--- a/package.json
+++ b/package.json
@@ -29,5 +29,5 @@
     "type": "git",
     "url": "git+https://github.com/mnemon-dev/mnemon.git"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Summary

- correct the npm package license metadata from `MIT` to `Apache-2.0`
- explain in the English and Chinese READMEs that the bracketed text is the standard Apache-2.0 Appendix template
- leave the canonical `LICENSE` text unchanged

The `[yyyy] [name of copyright owner]` lines reported in #88 are part of the official Apache-2.0 Appendix, not unresolved project metadata. Replacing them would modify the standard license text. The actionable mismatch was `package.json` advertising MIT while the repository ships Apache-2.0.

## Verification

- parsed `package.json` successfully
- `npm pack --dry-run --json`
- `git diff --check`
- `make test`

Closes #88.
