### PR TITLE
docs: center README headers and refresh project badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
   <img src="docs/logo/logo.svg" width="160" height="160" alt="Mnemon Logo" />
 </p>
 
-# Mnemon
+<h1 align="center">Mnemon</h1>
 
-**English** | [中文](docs/zh/README.md)
+<p align="center"><strong>English</strong> · <a href="docs/zh/README.md">中文</a></p>
 
-**LLM-supervised persistent memory for AI agents.**
+<p align="center">
+  <a href="https://www.npmjs.com/package/@mnemon-dev/mnemon"><img alt="npm version" src="https://img.shields.io/npm/v/@mnemon-dev/mnemon?label=npm" /></a>
+  <a href="https://github.com/mnemon-dev/mnemon/releases/latest"><img alt="GitHub release" src="https://img.shields.io/github/v/release/mnemon-dev/mnemon" /></a>
+  <a href="https://github.com/mnemon-dev/mnemon/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/mnemon-dev/mnemon?label=stars" /></a>
+  <a href="https://go.dev/"><img alt="Go 1.24+" src="https://img.shields.io/badge/Go-1.24%2B-00ADD8?logo=go&amp;logoColor=white" /></a>
+  <a href="https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" /></a>
+</p>
 
-[![Go 1.24+](https://img.shields.io/badge/Go-1.24%2B-00ADD8?logo=go&logoColor=white)](https://go.dev/)
-[![CI](https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml/badge.svg)](https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mnemon-dev/mnemon)](https://goreportcard.com/report/github.com/mnemon-dev/mnemon)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+<p align="center"><strong>LLM-supervised persistent memory for AI agents.</strong></p>
 
 ---
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -2,16 +2,20 @@
   <img src="../logo/logo.svg" width="160" height="160" alt="Mnemon Logo" />
 </p>
 
-# Mnemon
+<h1 align="center">Mnemon</h1>
 
-[English](../../README.md) | **中文**
+<p align="center"><a href="../../README.md">English</a> · <strong>中文</strong></p>
 
-**LLM 智能体的持久记忆系统** — LLM 监督式、钩子集成、四图架构。
+<p align="center">
+  <a href="https://www.npmjs.com/package/@mnemon-dev/mnemon"><img alt="npm 版本" src="https://img.shields.io/npm/v/@mnemon-dev/mnemon?label=npm" /></a>
+  <a href="https://github.com/mnemon-dev/mnemon/releases/latest"><img alt="GitHub 发布版本" src="https://img.shields.io/github/v/release/mnemon-dev/mnemon" /></a>
+  <a href="https://github.com/mnemon-dev/mnemon/stargazers"><img alt="GitHub 收藏数" src="https://img.shields.io/github/stars/mnemon-dev/mnemon?label=stars" /></a>
+  <a href="https://go.dev/"><img alt="Go 1.24+" src="https://img.shields.io/badge/Go-1.24%2B-00ADD8?logo=go&amp;logoColor=white" /></a>
+  <a href="https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml/badge.svg" /></a>
+  <a href="../../LICENSE"><img alt="许可证：Apache-2.0" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg" /></a>
+</p>
 
-[![Go 1.24+](https://img.shields.io/badge/Go-1.24%2B-00ADD8?logo=go&logoColor=white)](https://go.dev/)
-[![CI](https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml/badge.svg)](https://github.com/mnemon-dev/mnemon/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mnemon-dev/mnemon)](https://goreportcard.com/report/github.com/mnemon-dev/mnemon)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](../../LICENSE)
+<p align="center"><strong>LLM 智能体的持久记忆系统</strong> — LLM 监督式、钩子集成、四图架构。</p>
 
 ---
 


### PR DESCRIPTION
## What

Center the title, language switcher, badges, and tagline in both the English and Chinese README headers, following dsh-mnemon. Add npm version, latest GitHub release, and GitHub stars badges alongside the existing Go, CI, and Apache-2.0 badges. Download counts are intentionally omitted.

## Why

The logo was centered while the rest of the header was left aligned. The updated layout keeps both language editions consistent and exposes package and release information. Remove the obsolete Go Report Card badge because [the service has been sunset](https://goreportcard.com/) and its badge now reads `retired`.

## Checklist

- [x] Deterministic tests pass (`make test`)
- [x] Relevant E2E/process/Docker boundaries: not affected by this documentation-only change
- [x] Changed presentation verified through GitHub Markdown rendering and actual GitHub previews in both languages; badge responses and relative links checked
- [x] Documentation updated (`README.md` and `docs/zh/README.md`); content below the header is unchanged
- [x] User-facing release-note impact: README presentation only; no runtime or installation behavior changes
- [x] `git diff --check` passes
